### PR TITLE
記事関連のモデルの作成

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,4 +12,5 @@ class Article < ApplicationRecord
   }
 
   belongs_to :user
+  has_many :likes, dependent: :destroy
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -13,4 +13,8 @@ class Article < ApplicationRecord
 
   belongs_to :user
   has_many :likes, dependent: :destroy
+  has_many :liked_users, through: :likes, source: :user
+
+  has_many :keeps, dependent: :destroy
+  has_many :kept_users, through: :keeps, source: :user
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,15 @@
+class Article < ApplicationRecord
+  with_options presence: true do
+    validates :title
+    validates :content
+    validates :status
+  end
+
+  enum status: {
+    published: 0,
+    draft: 1,
+    closed: 2,
+  }
+
+  belongs_to :user
+end

--- a/app/models/keep.rb
+++ b/app/models/keep.rb
@@ -1,0 +1,9 @@
+class Keep < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+
+  validates :user_id, uniqueness: {
+    scope: :article_id,
+    message: "は同じ投稿に2回以上いいねはできません",
+  }
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,9 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+
+  validates :user_id, uniqueness: {
+    scope: :article_id,
+    message: "は同じ投稿に2回以上いいねはできません",
+  }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_one_attached :avatar
+  has_many :articles, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   validates :name, presence: true
   validates :profile, length: { maximum: 200 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,14 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_one_attached :avatar
+
   has_many :articles, dependent: :destroy
+
   has_many :likes, dependent: :destroy
+  has_many :liked_articles, through: :likes, source: :article
+
+  has_many :keeps, dependent: :destroy
+  has_many :kept_articles, through: :keeps, source: :article
 
   validates :name, presence: true
   validates :profile, length: { maximum: 200 }

--- a/db/migrate/20210731032030_create_articles.rb
+++ b/db/migrate/20210731032030_create_articles.rb
@@ -1,0 +1,12 @@
+class CreateArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :articles do |t|
+      t.string :title, null: false
+      t.text :content, null: false
+      t.integer :status, null: false, default: 0
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210731035449_create_likes.rb
+++ b/db/migrate/20210731035449_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :likes, [:user_id, :article_id], unique: true
+  end
+end

--- a/db/migrate/20210731040711_create_keeps.rb
+++ b/db/migrate/20210731040711_create_keeps.rb
@@ -1,0 +1,11 @@
+class CreateKeeps < ActiveRecord::Migration[6.1]
+  def change
+    create_table :keeps do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :keeps, [:user_id, :article_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_31_035449) do
+ActiveRecord::Schema.define(version: 2021_07_31_040711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,16 @@ ActiveRecord::Schema.define(version: 2021_07_31_035449) do
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
+  create_table "keeps", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_keeps_on_article_id"
+    t.index ["user_id", "article_id"], name: "index_keeps_on_user_id_and_article_id", unique: true
+    t.index ["user_id"], name: "index_keeps_on_user_id"
+  end
+
   create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "article_id", null: false
@@ -80,6 +90,8 @@ ActiveRecord::Schema.define(version: 2021_07_31_035449) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "users"
+  add_foreign_key "keeps", "articles"
+  add_foreign_key "keeps", "users"
   add_foreign_key "likes", "articles"
   add_foreign_key "likes", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_31_032030) do
+ActiveRecord::Schema.define(version: 2021_07_31_035449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,16 @@ ActiveRecord::Schema.define(version: 2021_07_31_032030) do
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_likes_on_article_id"
+    t.index ["user_id", "article_id"], name: "index_likes_on_user_id_and_article_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "profile"
@@ -70,4 +80,6 @@ ActiveRecord::Schema.define(version: 2021_07_31_032030) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "users"
+  add_foreign_key "likes", "articles"
+  add_foreign_key "likes", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_055056) do
+ActiveRecord::Schema.define(version: 2021_07_31_032030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,16 @@ ActiveRecord::Schema.define(version: 2021_07_30_055056) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "articles", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "content", null: false
+    t.integer "status", default: 0, null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "profile"
@@ -59,4 +69,5 @@ ActiveRecord::Schema.define(version: 2021_07_30_055056) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "articles", "users"
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :article do
+    title { "MyString" }
+    content { "MyText" }
+    status { 1 }
+    user { nil }
+  end
+end

--- a/spec/factories/keeps.rb
+++ b/spec/factories/keeps.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :keep do
+    user { nil }
+    article { nil }
+  end
+end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    user { nil }
+    article { nil }
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Article, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/keep_spec.rb
+++ b/spec/models/keep_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Keep, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/keep_spec.rb
+++ b/spec/models/keep_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Keep, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #6 

## 実装内容
- 記事関連のモデルの作成
  - `Article`モデル
    - 記事の状態を管理するために`enum`を使用
  - `Keep`モデル
  - `Like`モデル
- 作成したモデルは`User`モデルとの関連付けも実施済み
- タグ機能に関しては変更量が多くなったので以降のタスクで実施

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行