### PR TITLE
ヘッダー部の仮実装

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,18 @@
+<% if user_signed_in? %>
+  <li>
+    <%= link_to "投稿する", new_article_path %>
+  </li>
+  <li>
+    <%= link_to "アカウント編集", edit_user_registration_path %>
+  </li>
+  <li>
+    <%= link_to "ログアウト",  destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？"}  %>
+  </li>
+<% else %>
+  <li>
+    <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
+  </li>
+  <li>
+    <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
+  </li>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
   </head>
 
   <body>
+    <header>
+      <%= render "layouts/header" %>
+    </header>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
close #8 

## 実装内容
- ヘッダー部分にログイン機能を仮実装
  - ログインの有無で表示内容の分岐
  - 見た目の調整は`BootStrap`導入後に行う
  - 現状はとりあえずログアウトとログインを簡単にできるようにリンクを配置

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
