### PR TITLE
フラッシュ機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,3 +40,13 @@
 .mw-xl {
   max-width: 1200px;
 }
+
+// フラッシュ
+
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
       <%= render "layouts/header" %>
     </header>
     <main>
+      <%= render "layouts/flash" %>
       <div class="base-container <%= max_width %>">
       <%= yield %>
     </main>


### PR DESCRIPTION
close #12 

## 実装内容
- フラッシュ機能の実装
  - 画面幅いっぱいの表示
  - 部分テンプレートを用いて作成
  - 表示の色は`Bootstrap`から拝借

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行