### PR TITLE
ナビバーの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,6 +41,12 @@
   max-width: 1200px;
 }
 
+/* body */
+
+body {
+  padding-top: 60px;
+}
+
 // フラッシュ
 
 .alert-notice {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,15 +1,31 @@
-<% if user_signed_in? %>
-  <li>
-    <%= link_to "アカウント編集", edit_user_registration_path %>
-  </li>
-  <li>
-    <%= link_to "ログアウト",  destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？"}  %>
-  </li>
-<% else %>
-  <li>
-    <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
-  </li>
-  <li>
-    <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
-  </li>
-<% end %>
+
+<nav class="navbar navbar-expand-md navbar-light bg-light fixed-top">
+  <%= link_to "medimo", class: "navbar-brand" %>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+      <% if user_signed_in? %>
+        <div class="dropdown">
+          <li class="nav-item dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= current_user.name %>
+          </li>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+            <li class="dropdown-item"><%= link_to "投稿する" %></li>
+            <li class="dropdown-item"><%= link_to "マイページ" %></li>
+            <li class="dropdown-item"><%= link_to "アカウント編集", edit_user_registration_path %></li>
+            <li class="dropdown-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？"}%><li>
+          </div>
+        </div>
+      <% else %>
+        <li class="nav-item">
+          <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</nav>


### PR DESCRIPTION
close #11

## 実装内容
- ナビバーの実装
  - ナビロゴを文字で仮配置
  - 画面サイズが`md`以下時にハンバーガーメニューに切り替え
  - ログイン時はユーザーネームにドロップダウンをつけてページ遷移先の候補を配置
- デザインの崩れなど多いがデザインは最後の方に行う

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行