### PR TITLE
User modelのバリテーションテストの実装

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
   factory :user do
+    name { Faker::Lorem.characters(number: Random.new.rand(1..30)) }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,42 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "必要な情報が揃っているとき" do
+    let(:user) { build(:user) }
+    it "ユーザー登録できる" do
+      expect(user).to be_valid
+    end
+  end
+
+  context "ユーザーネームがないとき" do
+    let(:user) { build(:user, name: nil) }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+      expect(user.errors.details[:name][0][:error]).to eq :blank
+    end
+  end
+
+  context "メールアドレスがないとき" do
+    let(:user) { build(:user, email: nil) }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+      expect(user.errors.details[:email][0][:error]).to eq :blank
+    end
+  end
+
+  context "passwordがないとき" do
+    let(:user) { build(:user, password: nil) }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+      expect(user.errors.details[:password][0][:error]).to eq :blank
+    end
+  end
+
+  context "password確認が違うとき" do
+    let(:user) { build(:user, password_confirmation: "hoge") }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+      expect(user.errors.details[:password_confirmation][0][:error]).to eq :confirmation
+    end
+  end
 end


### PR DESCRIPTION
close #42 

## 実装内容
- `User model`のバリエーションテストを実施
  - 正常系と異常系の実施
  - 独自に追加した`name`カラムのテストも実装

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行