### PR TITLE
articleモデルのバリテーションテストの実装

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,8 +1,19 @@
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    content { "MyText" }
-    status { 1 }
-    user { nil }
+    title { Faker::Book.title }
+    content { Faker::Lorem.sentence }
+    user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
+
+    trait :closed do
+      status { :closed }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -34,4 +34,22 @@ RSpec.describe Article, type: :model do
       end
     end
   end
+
+  describe "異常系" do
+    context "titleが無いとき" do
+      let(:article) { build(:article, title: nil) }
+      it "記事の作成に失敗する" do
+        expect(article).to be_invalid
+        expect(article.errors.details[:title][0][:error]).to eq :blank
+      end
+    end
+
+    context "contentが無いとき" do
+      let(:article) { build(:article, content: nil) }
+      it "記事の作成に失敗する" do
+        expect(article).to be_invalid
+        expect(article.errors.details[:content][0][:error]).to eq :blank
+      end
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,5 +1,37 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "正常系" do
+    context "タイトルと本文と公開レベルが指定されているとき" do
+      let(:article) { build(:article) }
+      it "公開状態で記事が作成される" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
+    end
+
+    context "statusがpublishedのとき" do
+      let(:article) { build(:article, :published) }
+      it "公開状態で記事を作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
+    end
+
+    context "statusがdraftのとき" do
+      let(:article) { build(:article, :draft) }
+      it "下書き状態で記事を作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "statusがclosedのとき" do
+      let(:article) { build(:article, :closed) }
+      it "非公開状態で記事を作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "closed"
+      end
+    end
+  end
 end


### PR DESCRIPTION
close #44

## 実装内容
- `Articleモデル`のバリテーションテストを実施
  - `enum`の状態別のテスト実施
    - `enum`の利用には`trait`を使用
- 正常系と異常系を実装

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行