### PR TITLE
記事投稿機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "devise-bootstrap-views", "~> 1.0"
 gem "devise-i18n"
 gem "rails-i18n", "~> 6.0"
 
+gem "enum_help"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     devise-i18n (1.10.0)
       devise (>= 4.8.0)
     diff-lcs (1.4.4)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -271,6 +273,7 @@ DEPENDENCIES
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n
+  enum_help
   factory_bot_rails
   faker
   jbuilder (~> 2.7)

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -1,0 +1,36 @@
+//
+// Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+// the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+// inclusion directly in any other asset bundle and remove this file.
+//
+//= require trix/dist/trix
+
+// We need to override trix.css’s image gallery styles to accommodate the
+// <action-text-attachment> element we wrap around attachments. Otherwise,
+// images in galleries will be squished by the max-width: 33%; rule.
+.trix-content {
+  .attachment-gallery {
+    > action-text-attachment,
+    > .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%;
+    }
+
+    &.attachment-gallery--2,
+    &.attachment-gallery--4 {
+      > action-text-attachment,
+      > .attachment {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+    }
+  }
+
+  action-text-attachment {
+    .attachment {
+      padding: 0 !important;
+      max-width: 100% !important;
+    }
+  }
+}

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Articles controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,9 +3,12 @@ class ArticlesController < ApplicationController
   end
 
   def new
+    @article = Article.new
   end
 
   def create
+    @article = current_user.articles.create!(article_params)
+    redirect_to root_path
   end
 
   def edit
@@ -19,4 +22,10 @@ class ArticlesController < ApplicationController
 
   def destroy
   end
+
+  private
+
+    def article_params
+      params.require(:article).permit(:title, :content, :images, :status)
+    end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,22 @@
+class ArticlesController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def show
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,0 +1,2 @@
+module ArticlesHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,3 +12,6 @@ import "bootstrap/dist/js/bootstrap";
 Rails.start();
 Turbolinks.start();
 ActiveStorage.start();
+
+require("trix")
+require("@rails/actiontext")

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,7 +1,6 @@
 class Article < ApplicationRecord
   with_options presence: true do
     validates :title
-    validates :content
     validates :status
   end
 
@@ -20,4 +19,7 @@ class Article < ApplicationRecord
 
   has_many :tag_maps, dependent: :destroy
   has_many :tags, through: :tag_maps
+
+  has_rich_text :content
+  has_many_attached :images
 end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_with model: @article, local: true do |f| %>
+  <p>
+    <%= f.label :title  %>
+    <%= f.text_field :title, required: true %>
+  </p>
+  <p>
+    <%= f.label :content %>
+    <%= f.rich_text_area :content %>
+  </p>
+  <%= f.select :status, Article.statuses_i18n.invert %>
+  <%= f.submit "送信" %>
+<% end %>

--- a/app/views/articles/create.html.erb
+++ b/app/views/articles/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Articles#create</h1>
+<p>Find me in app/views/articles/create.html.erb</p>

--- a/app/views/articles/destroy.html.erb
+++ b/app/views/articles/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Articles#destroy</h1>
+<p>Find me in app/views/articles/destroy.html.erb</p>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Articles#edit</h1>
+<p>Find me in app/views/articles/edit.html.erb</p>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Articles#index</h1>
+<p>Find me in app/views/articles/index.html.erb</p>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Articles#new</h1>
+<p>Find me in app/views/articles/new.html.erb</p>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,2 +1,2 @@
-<h1>Articles#new</h1>
-<p>Find me in app/views/articles/new.html.erb</p>
+<h1>新規投稿</h1>
+<%= render "form" %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Articles#show</h1>
+<p>Find me in app/views/articles/show.html.erb</p>

--- a/app/views/articles/update.html.erb
+++ b/app/views/articles/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Articles#update</h1>
+<p>Find me in app/views/articles/update.html.erb</p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,11 @@
 ---
 ja:
+  enums:
+    article:
+      status:
+        published: "公開"
+        draft: "下書き"
+        closed: "非公開"
   activerecord:
     models:
       article: 記事

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root "articles#index"
   devise_for :users
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :articles
 end

--- a/db/migrate/20210802060638_create_action_text_tables.action_text.rb
+++ b/db/migrate/20210802060638_create_action_text_tables.action_text.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_text_rich_texts do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [:record_type, :record_id, :name], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end

--- a/db/migrate/20210802063858_rename_content_column_to_articles.rb
+++ b/db/migrate/20210802063858_rename_content_column_to_articles.rb
@@ -1,0 +1,5 @@
+class RenameContentColumnToArticles < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :articles, :content, :content_body
+  end
+end

--- a/db/migrate/20210802071147_remove_content_body_inarticles.rb
+++ b/db/migrate/20210802071147_remove_content_body_inarticles.rb
@@ -1,0 +1,5 @@
+class RemoveContentBodyInarticles < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :articles, :content_body, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_31_055250) do
+ActiveRecord::Schema.define(version: 2021_08_02_071147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -45,7 +55,6 @@ ActiveRecord::Schema.define(version: 2021_07_31_055250) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title", null: false
-    t.text "content", null: false
     t.integer "status", default: 0, null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "private": true,
   "dependencies": {
     "@rails/actioncable": "^6.0.0",
+    "@rails/actiontext": "^6.1.4",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.0",
     "bootstrap": "~4.5.1",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
+    "trix": "^1.2.0",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,11 +5,10 @@ require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
+# Add additional requires below this line. Rails is not loaded until this point!
 
 # Fakerの日本語化
 Faker::Config.locale = :ja
-
-# Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Articles", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/articles/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/articles/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/articles/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/articles/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/articles/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /update" do
+    it "returns http success" do
+      get "/articles/update"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/articles/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/views/articles/create.html.erb_spec.rb
+++ b/spec/views/articles/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "articles/create.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/articles/destroy.html.erb_spec.rb
+++ b/spec/views/articles/destroy.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "articles/destroy.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/articles/edit.html.erb_spec.rb
+++ b/spec/views/articles/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "articles/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/articles/index.html.erb_spec.rb
+++ b/spec/views/articles/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "articles/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/articles/new.html.erb_spec.rb
+++ b/spec/views/articles/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "articles/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/articles/show.html.erb_spec.rb
+++ b/spec/views/articles/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "articles/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/articles/update.html.erb_spec.rb
+++ b/spec/views/articles/update.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "articles/update.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,6 +898,13 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.4.tgz#c3c5a9f8302c429af9722b6c50ab48049016d2a3"
   integrity sha512-0LmSKJTuo2dL6BQ+9xxLnS9lbkyfz2mBGeBnQ2J7o9Bn0l0q+ZC6VuoZMZZXPvABI4QT7Nfknv5WhfKYL+boew==
 
+"@rails/actiontext@^6.1.4":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-6.1.4.tgz#ed8c7d2b68d66205301f4538ce65d04c48031f6b"
+  integrity sha512-KG+VCofmfZAhW1x1xFxMC2sZtvwbx+XX0Y+dzeBFjKU1jZMM0RNytJf5EiuHtD9fL71zz6/nMT7FjwOFenSA7Q==
+  dependencies:
+    "@rails/activestorage" "^6.0.0"
+
 "@rails/activestorage@^6.0.0":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-6.1.4.tgz#7772f539cc846df5f4364fc57ccb48860f9e966e"
@@ -6422,6 +6429,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+trix@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.3.1.tgz#ccce8d9e72bf0fe70c8c019ff558c70266f8d857"
+  integrity sha512-BbH6mb6gk+AV4f2as38mP6Ucc1LE3OD6XxkZnAgPIduWXYtvg2mI3cZhIZSLqmMh9OITEpOBCCk88IVmyjU7bA==
 
 ts-pnp@^1.1.6:
   version "1.2.0"


### PR DESCRIPTION
close #15 

## 実装内容
- 記事投稿機能の実装
  - `Action Text`を導入
  - `Active Strage`利用を可能に変更
  - `enum-help`を導入し投稿時の公開レベルを日本語に変更
  - `Action Text`導入により`Articleモデル`の`content`カラムが不要だと発覚しカラムを削除
 
## チェックリスト
【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行