### PR TITLE
記事詳細ページの実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -15,6 +15,7 @@ class ArticlesController < ApplicationController
   end
 
   def show
+    @article = Article.published.find(params[:id])
   end
 
   def update

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,2 +1,11 @@
-<h1>Articles#show</h1>
-<p>Find me in app/views/articles/show.html.erb</p>
+<%= "#{@article.user.name} が#{l @article.updated_at, format: :medium}に更新" %>
+<h1><%= @article.title %></h1>
+<%= @article.content %>
+
+<% if current_user.id == @article.user_id %>
+  <p>
+    <%= link_to "編集", edit_article_path(@article) %>
+    <%= link_to "削除", article_path(@article), method: :delete, data: { confirm: "削除しますか？" } %>
+  </p>
+<% end %>
+<%= link_to "投稿一覧へ", root_path %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -228,5 +228,6 @@ ja:
     formats:
       default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       long: "%Y/%m/%d %H:%M"
+      medium: "%Y年/%m月/%d日"
       short: "%m/%d %H:%M"
     pm: 午後


### PR DESCRIPTION
close #16

## 実装内容
- `Articles#show`の実装
  - 公開済の記事を対象に限定
  - viewは表示の確認だけの仮実装
  - `updated_at`の表示を変えるために`ja.yml`に新しい`Time format`を用意
  - 執筆者の時だけ「編集・削除」リンクの表示

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行