### PR TITLE
タイトル・タグ検索機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "devise-i18n"
 gem "rails-i18n", "~> 6.0"
 
 gem "enum_help"
+gem "ransack"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    ransack (2.4.2)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -287,6 +291,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.2)
   rails-i18n (~> 6.0)
+  ransack
   rspec-rails
   rubocop-rails
   rubocop-rspec

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the home controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,6 +3,8 @@ class ArticlesController < ApplicationController
   before_action :authenticate_user!, only: %i[create update destroy]
 
   def index
+    @q = Article.published.ransack(params[:q])
+    @search_articles = @q.result
     @articles = Article.published.order(updated_at: :desc)
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,7 +5,6 @@ class ArticlesController < ApplicationController
   def index
     @q = Article.published.ransack(params[:q])
     @search_articles = @q.result
-    @articles = Article.published.order(updated_at: :desc)
   end
 
   def new

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,6 @@
+class HomeController < ApplicationController
+  def index
+    @articles = Article.published.order(updated_at: :desc)
+    @q = Article.published.ransack(params[:q])
+  end
+end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,2 +1,12 @@
+<%= search_form_for @q do |f| %>
+  <%= f.label :title, "タイトル" %>
+  <%= f.search_field :title_cont %>
+  <%= f.submit "検索" %>
+<% end %>
+
+<% @search_articles.each do |article|  %>
+  <%= link_to article.title, article_path(article) %>
+<% end  %>
+
 <h1>最新の投稿一覧</h1>
 <%= render @articles %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,12 +1,6 @@
-<%= search_form_for @q do |f| %>
-  <%= f.label :title, "タイトル" %>
-  <%= f.search_field :title_cont %>
-  <%= f.submit "検索" %>
+<h3>検索結果</h3>
+<% if @search_articles.blank? %>
+  該当の記事が見つかりませんでした。
+<% else  %>
+  <%= render @search_articles %>
 <% end %>
-
-<% @search_articles.each do |article|  %>
-  <%= link_to article.title, article_path(article) %>
-<% end  %>
-
-<h1>最新の投稿一覧</h1>
-<%= render @articles %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,9 @@
+<%= search_form_for @q, url: articles_path do |f| %>
+  <%= f.label :title, "記事・タグ検索" %>
+  <%= f.search_field :title_or_tags_tag_name_cont, placeholder: "キーワードを入力", required: true %>
+  <%= f.submit "検索" %>
+<% end %>
+
+
+<h1>最新の投稿一覧</h1>
+<%= render @articles %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
-  root "articles#index"
+  root "home#index"
 
   devise_for :users, controllers: {
     registrations: "users/registrations",
   }
-
+  resources :users, only: [:show]
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Homes", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
close #19

## 実装内容
- 記事・タグ検索機能の実装
  - `home`コントローラーを作成し`root`をこちらに変更
  - `Articles#index`は記事の検索結果の一覧ページに変更
- `Gem ransack`を使用
  - `root`ページ上で検索できるように実装
  -  検索ワードが`記事タイトル`と`タグ`どちらかに含まれているものを結果に返す

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行