### PR TITLE
下書き記事一覧の実装

### DIFF
--- a/app/assets/stylesheets/articles/drafts.scss
+++ b/app/assets/stylesheets/articles/drafts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the articles/drafts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/articles/drafts_controller.rb
+++ b/app/controllers/articles/drafts_controller.rb
@@ -1,0 +1,5 @@
+class Articles::DraftsController < ApplicationController
+  def index
+    @draft_articles = current_user.articles.draft.order(updated_at: :desc)
+  end
+end

--- a/app/helpers/articles/drafts_helper.rb
+++ b/app/helpers/articles/drafts_helper.rb
@@ -1,0 +1,2 @@
+module Articles::DraftsHelper
+end

--- a/app/views/articles/drafts/_draft_article.html.erb
+++ b/app/views/articles/drafts/_draft_article.html.erb
@@ -1,0 +1,3 @@
+<% @draft_articles.each do |article| %>
+  <p><%= link_to article.title, article_path(article) %></p>
+<% end %>

--- a/app/views/articles/drafts/index.html.erb
+++ b/app/views/articles/drafts/index.html.erb
@@ -1,0 +1,2 @@
+<h1>下書き記事一覧</h1>
+<%= render "draft_article", draft_articles: @draft_articles %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -14,6 +14,7 @@
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
             <li class="dropdown-item"><%= link_to "投稿する" %></li>
             <li class="dropdown-item"><%= link_to "マイページ", mypage_path(current_user) %></li>
+            <li class="dropdown-item"><%= link_to "下書き記事一覧", articles_drafts_path %></li>
             <li class="dropdown-item"><%= link_to "アカウント編集", edit_user_registration_path %></li>
             <li class="dropdown-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？"}%><li>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
 
+  namespace :articles do
+    resources :drafts, only: [:index]
+  end
+
   resources :articles do
     resource :likes, only: [:create, :destroy]
     resource :keeps, only: [:create, :destroy]

--- a/spec/requests/articles/drafts_spec.rb
+++ b/spec/requests/articles/drafts_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Articles::Drafts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
close #55

## 実装内容
- 自分の下書き記事一覧ページの実装
  - `articles/drafts_controller`の作成 
  - 下書き状態で保存されている記事群を表示

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
