### PR TITLE
非公開・下書き記事へのurl手打ち対策

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,11 @@ class ApplicationController < ActionController::Base
       # アカウント編集の時にnameとprofileとavatarのストロングパラメータを追加
       devise_parameter_sanitizer.permit(:account_update, keys: [:name, :profile, :avatar])
     end
+
+    def correct_user
+      @article = current_user.articles.closed.find_by(id: params[:id])
+      unless @article
+        redirect_to root_path, alert: "指定した記事は閲覧できません"
+      end
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,11 +12,4 @@ class ApplicationController < ActionController::Base
       # アカウント編集の時にnameとprofileとavatarのストロングパラメータを追加
       devise_parameter_sanitizer.permit(:account_update, keys: [:name, :profile, :avatar])
     end
-
-    def correct_user
-      @article = current_user.articles.closed.find_by(id: params[:id])
-      unless @article
-        redirect_to root_path, alert: "指定した記事は閲覧できません"
-      end
-    end
 end

--- a/app/controllers/articles/closes_controller.rb
+++ b/app/controllers/articles/closes_controller.rb
@@ -1,17 +1,19 @@
 class Articles::ClosesController < ApplicationController
-  before_action :correct_user, only: [:show]
+  before_action :closed_owner, only: [:show]
   def index
     @closed_articles = current_user.articles.closed.order(updated_at: :desc)
   end
 
   def show
-    # @article = current_user.articles.closed.find(params[:id])
+    @article = current_user.articles.closed.find(params[:id])
   end
 
-  def correct_user
-    @article = current_user.articles.closed.find_by(id: params[:id])
-    unless @article
-      redirect_to root_path
+  private
+
+    def closed_owner
+      @article = current_user.articles.closed.find_by(id: params[:id])
+      unless @article
+        redirect_to root_path, alert: "指定した記事は閲覧できません"
+      end
     end
-  end
 end

--- a/app/controllers/articles/closes_controller.rb
+++ b/app/controllers/articles/closes_controller.rb
@@ -1,9 +1,17 @@
 class Articles::ClosesController < ApplicationController
+  before_action :correct_user, only: [:show]
   def index
     @closed_articles = current_user.articles.closed.order(updated_at: :desc)
   end
 
   def show
-    @article = current_user.articles.closed.find(params[:id])
+    # @article = current_user.articles.closed.find(params[:id])
+  end
+
+  def correct_user
+    @article = current_user.articles.closed.find_by(id: params[:id])
+    unless @article
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/articles/closes_controller.rb
+++ b/app/controllers/articles/closes_controller.rb
@@ -2,4 +2,8 @@ class Articles::ClosesController < ApplicationController
   def index
     @closed_articles = current_user.articles.closed.order(updated_at: :desc)
   end
+
+  def show
+    @article = current_user.articles.closed.find(params[:id])
+  end
 end

--- a/app/controllers/articles/drafts_controller.rb
+++ b/app/controllers/articles/drafts_controller.rb
@@ -1,10 +1,20 @@
 class Articles::DraftsController < ApplicationController
-before_action :correct_user, only: [:show]
+  before_action :draft_owner, only: [:show]
 
   def index
     @draft_articles = current_user.articles.draft.order(updated_at: :desc)
   end
 
   def show
+    @article = current_user.articles.draft.find(params[:id])
   end
+
+  private
+
+    def draft_owner
+      @article = current_user.articles.draft.find_by(id: params[:id])
+      unless @article
+        redirect_to root_path, alert: "指定した記事は閲覧できません"
+      end
+    end
 end

--- a/app/controllers/articles/drafts_controller.rb
+++ b/app/controllers/articles/drafts_controller.rb
@@ -1,5 +1,10 @@
 class Articles::DraftsController < ApplicationController
+before_action :correct_user, only: [:show]
+
   def index
     @draft_articles = current_user.articles.draft.order(updated_at: :desc)
+  end
+
+  def show
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-  before_action :set_article, only: %i[edit update destroy]
+  before_action :set_article, only: %i[edit update destroy show]
   before_action :authenticate_user!, only: %i[create update destroy]
 
   def index
@@ -34,7 +34,6 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    @article = Article.find(params[:id])
     @article_tags = @article.tags
   end
 
@@ -66,6 +65,6 @@ class ArticlesController < ApplicationController
     end
 
     def set_article
-      @article = Article.find(params[:id])
+      @article = Article.published.find(params[:id])
     end
 end

--- a/app/views/articles/closes/index.html.erb
+++ b/app/views/articles/closes/index.html.erb
@@ -1,4 +1,4 @@
 <h1>非公開記事一覧</h1>
 <% @closed_articles.each do |article| %>
-  <p><%= link_to article.title, article_path(article) %></p>
+  <p><%= link_to article.title, articles_close_path(article) %></p>
 <%end  %>

--- a/app/views/articles/closes/show.html.erb
+++ b/app/views/articles/closes/show.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @article.title %></h1>
+<%= @article.content %>

--- a/app/views/articles/drafts/_draft_article.html.erb
+++ b/app/views/articles/drafts/_draft_article.html.erb
@@ -1,3 +1,0 @@
-<% @draft_articles.each do |article| %>
-  <p><%= link_to article.title, article_path(article) %></p>
-<% end %>

--- a/app/views/articles/drafts/index.html.erb
+++ b/app/views/articles/drafts/index.html.erb
@@ -1,2 +1,4 @@
 <h1>下書き記事一覧</h1>
-<%= render "draft_article", draft_articles: @draft_articles %>
+<% @draft_articles.each do |article| %>
+  <p><%= link_to article.title, articles_draft_path(article) %></p>
+<% end %>

--- a/app/views/articles/drafts/show.html.erb
+++ b/app/views/articles/drafts/show.html.erb
@@ -1,0 +1,2 @@
+<%= @article.title %>
+<%= @article.content %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   namespace :articles do
     resources :drafts, only: [:index]
-    resources :closes, only: [:index]
+    resources :closes, only: [:index, :show]
   end
 
   resources :articles do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   end
 
   namespace :articles do
-    resources :drafts, only: [:index]
+    resources :drafts, only: [:index, :show]
     resources :closes, only: [:index, :show]
   end
 


### PR DESCRIPTION
close #59

## 実装内容
- 非公開・下書き記事への本人以外のアクセスを制限
  - `draft`・`closed`の各コントローラーに`before_action`を設置
  - 作者以外がアクセスした際には`root`ページにリダイレクトされる
 
## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行