### PR TITLE
非公開記事編集機能の実装

### DIFF
--- a/app/controllers/articles/closes_controller.rb
+++ b/app/controllers/articles/closes_controller.rb
@@ -1,5 +1,6 @@
 class Articles::ClosesController < ApplicationController
   before_action :closed_owner, only: [:show]
+  before_action :authenticate_user!, only: %i[index show]
   def index
     @closed_articles = current_user.articles.closed.order(updated_at: :desc)
   end

--- a/app/controllers/articles/drafts_controller.rb
+++ b/app/controllers/articles/drafts_controller.rb
@@ -1,5 +1,6 @@
 class Articles::DraftsController < ApplicationController
   before_action :draft_owner, only: [:show]
+  before_action :authenticate_user!, only: %i[index show]
 
   def index
     @draft_articles = current_user.articles.draft.order(updated_at: :desc)

--- a/app/views/articles/closes/show.html.erb
+++ b/app/views/articles/closes/show.html.erb
@@ -1,2 +1,3 @@
 <h1><%= @article.title %></h1>
 <%= @article.content %>
+<%= link_to "編集", edit_article_path(@article) %>


### PR DESCRIPTION
close #61

## 実装内容
- 非公開記事の編集機能実装
  - 編集先は`Articles#edit`を使用
  - 非ログイン者が下書き・非公開ページに移動できてしまうのを制限

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行