### PR TITLE
プロフィールページの実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,9 +1,27 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :ensure_normal_user, only: %i[update destroy] # rubocop:disable Rails/LexicallyScopedActionFilter
+  before_action :ensure_normal_user, only: %i[profile_update update destroy] # rubocop:disable Rails/LexicallyScopedActionFilter
 
   def ensure_normal_user
-    if resource.email == "guest@example.com"
-      redirect_to root_path, alert: "ゲストユーザーは更新・削除はできません。"
+    if current_user.email == "guest@example.com"
+      redirect_to mypage_path(current_user), alert: "ゲストユーザーは更新・削除はできません。"
     end
   end
+
+  def profile_edit
+  end
+
+  def profile_update
+    current_user.assign_attributes(account_update_params)
+    if current_user.save
+      redirect_to mypage_path(current_user), notice: "プロフィールを更新しました"
+    else
+      render "profile_edit"
+    end
+  end
+
+  protected
+
+    def configure_account_update_params
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name, :profile, :avatar])
+    end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,11 +4,6 @@
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group">
-    <%= f.label :name %>
-    <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control' %>
-  </div>
-
-  <div class="form-group">
     <%= f.label :email %>
     <%= f.email_field :email, autocomplete: 'email', class: 'form-control' %>
   </div>
@@ -30,11 +25,6 @@
     <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
 
     <small class="form-text text-muted"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></small>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :profile %>
-    <%= f.text_area :profile, autofocus: true, autocomplete: 'profile', class: 'form-control' %>
   </div>
 
   <div class="form-group">

--- a/app/views/devise/registrations/profile_edit.html.erb
+++ b/app/views/devise/registrations/profile_edit.html.erb
@@ -1,0 +1,21 @@
+<%= form_for current_user, url: profile_update_path do |f| %>
+
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :profile %>
+    <%= f.text_area :profile, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :avatar %>
+    <%= f.file_field :avator, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit "更新", class: 'btn btn-primary btn-block' %>
+  </div>
+<% end %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -1,3 +1,6 @@
+
+<h3><%= link_to "プロフィール編集", profile_edit_path %></h3>
+
 <p>名前</p>
 <%= @user.name %>
 <p>投稿本数</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   }
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
+    get "profile_edit", to: "users/registrations#profile_edit", as: "profile_edit"
+    patch "profile_update", to: "users/registrations#profile_update", as: "profile_update"
   end
 
   namespace :articles do


### PR DESCRIPTION
close #30

## 実装内容
- プロフィールページの実装
  - アカウント編集の`name`,　`profile`を移動しアイコン設定可能
  - ゲストユーザーは変更不可の使用
  - マイページ内にプロフィール編集リンクを配置
 
## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行