### PR TITLE
Action_Text使用時の画像の表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "jbuilder", "~> 2.7"
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem "image_processing", "~> 1.2"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     kaminari (1.2.1)
@@ -234,6 +237,8 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.2)
+      ffi (~> 1.12)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -292,6 +297,7 @@ DEPENDENCIES
   enum_help
   factory_bot_rails
   faker
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.3)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
             <%= current_user.name %>
           </li>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-            <li class="dropdown-item"><%= link_to "投稿する" %></li>
+            <li class="dropdown-item"><%= link_to "投稿する", new_article_path %></li>
             <li class="dropdown-item"><%= link_to "マイページ", mypage_path(current_user) %></li>
             <li class="dropdown-item"><%= link_to "下書き記事一覧", articles_drafts_path %></li>
             <li class="dropdown-item"><%= link_to "非公開記事一覧", articles_closes_path %></li>


### PR DESCRIPTION
close #67

## 実装内容
- `Action_Text`使用時の画像の表示されないのを改善
  - `gem "image_processing", "~> 1.2"` の導入
    - 画像添付しての作成・編集の動作確認済
  - ヘッダー内の`投稿する`ボタンにリンクを配置

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行