### PR TITLE
英語表記部分の日本語化

### DIFF
--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -4,7 +4,7 @@
     <%= f.text_field :title, placeholder: "タイトル", required: true %>
   </p>
   <p>
-    <%= f.label :tag %>
+    <%= f.label :tag_name %>
     <%= f.text_field :tag_name, value: @tag_list, placeholder: "スペース区切りで入力 (例: 外科 手術)" %>
   </p>
   <p>

--- a/app/views/devise/registrations/profile_edit.html.erb
+++ b/app/views/devise/registrations/profile_edit.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :avatar %>
+    <%= f.label :avatar, "ユーザーアイコン" %>
     <%= f.file_field :avatar, class: 'form-control' %>
   </div>
 

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -98,7 +98,7 @@ ja:
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
-        title: "%{resource}編集"
+        title: "アカウント編集"
         unhappy: 気に入りません
         update: 更新
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -236,6 +236,6 @@ ja:
     formats:
       default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       long: "%Y/%m/%d %H:%M"
-      medium: "%Y年/%m月/%d日"
+      medium: "%Y年%m月%d日"
       short: "%m/%d %H:%M"
     pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,7 @@ ja:
         content: 本文
         status: 公開範囲
         user: ユーザー
+        tag_name: タグ
       keep:
         user: ユーザー
         article: 記事


### PR DESCRIPTION
close #71

## 実装内容
- 英語や日付表示の修正
  - [x] profile_editの「avatar」表示を「ユーザーアイコン」に変更
  - [x] 投稿画面の「Tag_name」を「タグ」に変更 
  - [x] 自作した時間のデフォルトを修正
  - [x] `users/edit`のタイトルが「User編集」から「アカウント編集」に変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行