### PR TITLE
記事詳細画面での画像サイズを変更

### DIFF
--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -6,9 +6,6 @@
   <figcaption class="attachment__caption">
     <% if caption = blob.try(:caption) %>
       <%= caption %>
-    <% else %>
-      <span class="attachment__name"><%= blob.filename %></span>
-      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
     <% end %>
   </figcaption>
 </figure>

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,7 +1,5 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
-  <% if blob.representable? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
-  <% end %>
+  <%= image_tag blob.variant(resize: "300x300").processed if blob.representable?%>
 
   <figcaption class="attachment__caption">
     <% if caption = blob.try(:caption) %>


### PR DESCRIPTION
close #82

## 実装内容
- 記事詳細画面での表示サイズを変更
- 画像に説明文を書く場合は表示し、ない場合はファイル名・画像容量の表示をオフに変更

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
