### PR TITLE
N+1対策

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development do
   gem "rack-mini-profiler", "~> 2.0"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "annotate"
+  gem "bullet"
   gem "spring"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,9 @@ GEM
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.4)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
@@ -266,6 +269,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
+    uniform_notifier (1.14.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -290,6 +294,7 @@ PLATFORMS
 DEPENDENCIES
   annotate
   bootsnap (>= 1.4.4)
+  bullet
   byebug
   devise
   devise-bootstrap-views (~> 1.0)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -58,7 +58,8 @@ class ArticlesController < ApplicationController
 
   def search
     @tag = Tag.find(params[:tag_id])
-    @articles = @tag.articles.published.order(updated_at: :desc).page(params[:page]).per(PER_PAGE)
+    @articles = @tag.articles.published.includes(:keeps, :tags, :tag_maps,
+                                                 user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
   private

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,7 +5,8 @@ class ArticlesController < ApplicationController
 
   def index
     @q = Article.published.ransack(params[:q])
-    @search_articles = @q.result.page(params[:page]).per(PER_PAGE)
+    @search_articles = @q.result.order(created_at: :desc).includes(:keeps, :tags, :tag_maps,
+                                                                   user: { avatar_attachment: :blob }).page(params[:page]).per(PER_PAGE)
   end
 
   def new

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,7 @@
 class HomeController < ApplicationController
   def index
-    @articles = Article.published.order(updated_at: :desc).page(params[:page]).per(PER_PAGE)
+    @articles = Article.published.includes(:tag_maps, :tags, :keeps,
+                                           user: { avatar_attachment: :blob }).order(updated_at: :desc).page(params[:page]).per(PER_PAGE)
     @q = Article.published.ransack(params[:q])
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
   def index
     @articles = Article.published.includes(:tag_maps, :tags, :keeps,
-                                           user: { avatar_attachment: :blob }).order(updated_at: :desc).page(params[:page]).per(PER_PAGE)
+                                           user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     @q = Article.published.ransack(params[:q])
   end
 end

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -2,7 +2,8 @@ class MypageController < ApplicationController
   before_action :authenticate_user!, only: %i[index show]
   # 保存した記事一覧のページ
   def index
-    @articles = current_user.kept_articles.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    @articles = current_user.kept_articles.includes(:tag_maps, :tags, :keeps,
+                                                    user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
   def show

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -6,7 +6,7 @@ class MypageController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
-    @articles = @user.articles.published.order(updated_at: :desc).page(params[:page]).per(PER_PAGE)
+    @user = User.with_attached_avatar.find(params[:id])
+    @articles = @user.articles.published.includes(:keeps, :tags, :tag_maps).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -1,7 +1,7 @@
 
 <%= image_tag user_icon(@user, "small") %>
 <p><%= "@#{@user.name}" %></p>
-<p><%= "投稿数#{@user.articles.count}" %></p>
+<p><%= "投稿数#{@user.articles.published.count}" %></p>
 
 <%= @user.profile %>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,16 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+  # Bullet.growl         = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
     Bullet.alert         = true
     Bullet.bullet_logger = true
     Bullet.console       = true
-  # Bullet.growl         = true
+    # Bullet.growl         = true
     Bullet.rails_logger  = true
     Bullet.add_footer    = true
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,7 @@ Rails.application.configure do
     # Bullet.growl         = true
     Bullet.rails_logger  = true
     Bullet.add_footer    = true
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Article", association: :keeps
   end
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true # raise an error if n+1 query occurs
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = false


### PR DESCRIPTION
close #86

## 実装内容
- 各ページのN+1に対応
  - `get bullet` を使用
  - 非ログイン時に`Article :keeps`に`eager_loading`の指摘があったのでホワイトリストに追加。

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行