### PR TITLE
非ログイン時にユーザーページを閲覧可能に変更

### DIFF
--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,5 +1,5 @@
 class MypageController < ApplicationController
-  before_action :authenticate_user!, only: %i[index show]
+  before_action :authenticate_user!, only: %i[index]
   # 保存した記事一覧のページ
   def index
     @articles = current_user.kept_articles.includes(:tag_maps, :tags, :keeps,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
   end
 
   def account_owner?(user)
-    user.id == current_user.id
+    current_user.id.to_s == params[:id]
   end
 
   def creation_date(article)

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -5,7 +5,7 @@
 
 <%= @user.profile %>
 
-<% if account_owner?(@user) %>
+<% if user_signed_in? && account_owner?(@user) %>
   <h3><%= link_to "プロフィール編集", profile_edit_path %></h3>
 <% end %>
 <h4>最近の投稿</h4>


### PR DESCRIPTION
close #90

## 実装内容
- タイトル通り
  - `helper`の一部改修し該当のviewに適用
  - ` before_action :authenticate_user!, only: %i[index]` のみに変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
