### PR TITLE
マイページの記事表示の実装

### DIFF
--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -9,5 +9,7 @@ class MypageController < ApplicationController
   def show
     @user = User.with_attached_avatar.find(params[:id])
     @articles = @user.articles.published.includes(:keeps, :tags, :tag_maps).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    @draft_articles = @user.articles.draft.order(created_at: :desc).limit(PER_PAGE)
+    @closed_articles = @user.articles.closed.order(created_at: :desc).limit(PER_PAGE)
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,10 +15,8 @@
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
             <li class="dropdown-item"><%= link_to "マイページ", mypage_path(current_user) %></li>
             <li class="dropdown-item"><%= link_to "保存記事一覧", mypage_index_path %></li>
-            <li class="dropdown-item"><%= link_to "下書き記事一覧", articles_drafts_path %></li>
-            <li class="dropdown-item"><%= link_to "非公開記事一覧", articles_closes_path %></li>
             <li class="dropdown-item"><%= link_to "アカウント編集", edit_user_registration_path %></li>
-            <li class="dropdown-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？"}%><li>
+            <li class="dropdown-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete %><li>
           </div>
         </div>
       <% else %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -27,13 +27,15 @@
     </div>
 
     <div class="mb-5 tab-pane fade" id="draft" role="tabpanel" aria-labelledby="draft-tab">
-      <div class="ml-1 mt-5 mb-2"><%= link_to "下書き記事一覧", articles_closes_path %></div>
+      <div class="ml-1 mt-5 mb-2"></div>
       <%= render partial: "articles/drafts/draft_article", collection: @draft_articles %>
+      <%= link_to "下書き記事一覧へ", articles_drafts_path %>
     </div>
 
     <div class="mb-5 tab-pane fade" id="closed" role="tabpanel" aria-labelledby="closed-tab">
-      <div class="ml-1 mt-5 mb-2"><%= link_to "非公開記事一覧", articles_drafts_path %></div>
+      <div class="ml-1 mt-5 mb-2"></div>
       <%= render partial: "articles/closes/closed_article", collection: @closed_articles %>
+      <%= link_to "非公開記事一覧へ", articles_closes_path %>
     </div>
   </div>
 <% else %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -4,11 +4,40 @@
 <p><%= "投稿数#{@user.articles.published.count}" %></p>
 
 <%= @user.profile %>
-
 <% if user_signed_in? && account_owner?(@user) %>
   <h3><%= link_to "プロフィール編集", profile_edit_path %></h3>
-<% end %>
-<h4>最近の投稿</h4>
 
-<%= render @articles %>
-<%= paginate @articles %>
+  <ul class="text-center nav nav-tabs" id="myTab" role="tablist">
+    <li class="nav-item bg-light">
+      <a class="nav-link active link-text" id="published-tab" data-toggle="tab" href="#published" role="tab" aria-controls="published" aria-selected="true">公開記事</a>
+    </li>
+    <li class="nav-item bg-light">
+      <a class="nav-link link-text" id="draft-tab" data-toggle="tab" href="#draft" role="tab" aria-controls="draft" aria-selected="false">下書き</a>
+    </li>
+    <li class="nav-item bg-light">
+      <a class="nav-link link-text" id="closed-tab" data-toggle="tab" href="#closed" role="tab" aria-controls="closed" aria-selected="false">非公開</a>
+    </li>
+  </ul>
+
+  <div class="tab-content" id="myTabContent">
+    <div class="tab-pane fade show active" id="published" role="tabpanel" aria-labelledby="published-tab">
+      <div class="ml-1 mt-3 mb-2"></div>
+      <%= render @articles %>
+      <%= paginate @articles %>
+    </div>
+
+    <div class="mb-5 tab-pane fade" id="draft" role="tabpanel" aria-labelledby="draft-tab">
+      <div class="ml-1 mt-5 mb-2"><%= link_to "下書き記事一覧", articles_closes_path %></div>
+      <%= render partial: "articles/drafts/draft_article", collection: @draft_articles %>
+    </div>
+
+    <div class="mb-5 tab-pane fade" id="closed" role="tabpanel" aria-labelledby="closed-tab">
+      <div class="ml-1 mt-5 mb-2"><%= link_to "非公開記事一覧", articles_drafts_path %></div>
+      <%= render partial: "articles/closes/closed_article", collection: @closed_articles %>
+    </div>
+  </div>
+<% else %>
+  <h4>最近の投稿</h4>
+  <%= render @articles %>
+  <%= paginate @articles %>
+<% end %>


### PR DESCRIPTION
close #92

## 実装内容
- マイページでの記事一覧の表示方法を変更
  - 公開済みの記事のみの表示からアクセスページが自分の物であれば[公開済・下書き・非公開]とタブで表示される
  - 下書き・非公開記事は上限を10として以降は各記事の一覧ページに移動するように配置
  - ヘッダー内の「下書き・非公開一覧」へのリンクは重複するので削除

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行