### PR TITLE
ヘッダー部のレイアウトを変更

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,35 +1,27 @@
-
 <nav class="navbar navbar-expand-md navbar-light bg-light fixed-top">
   <%= link_to "medimo", root_path, class: "navbar-brand" %>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-  <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav mr-auto">
-      <% if user_signed_in? %>
-        <li class="nav-item"><%= link_to "投稿する", new_article_path, class: "nav-link" %></li>
-        <div class="dropdown">
-          <li class="nav-item dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= image_tag user_icon(current_user, "medium") %>
-          </li>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-            <li class="dropdown-item"><%= link_to "マイページ", mypage_path(current_user) %></li>
-            <li class="dropdown-item"><%= link_to "保存記事一覧", mypage_index_path %></li>
-            <li class="dropdown-item"><%= link_to "アカウント編集", edit_user_registration_path %></li>
-            <li class="dropdown-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete %><li>
-          </div>
+    <% if user_signed_in? %>
+      <button class="nav-item"><%= link_to "投稿する", new_article_path, class: "nav-link" %></button>
+      <div class="dropdown">
+        <li class="nav-item dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <%= image_tag user_icon(current_user, "medium") %>
+        </li>
+        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+          <li class="dropdown-item"><%= link_to "マイページ", mypage_path(current_user) %></li>
+          <li class="dropdown-item"><%= link_to "保存記事一覧", mypage_index_path %></li>
+          <li class="dropdown-item"><%= link_to "アカウント編集", edit_user_registration_path %></li>
+          <li class="dropdown-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete %><li>
         </div>
-      <% else %>
-        <li class="nav-item">
-          <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "nav-link" %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+      </div>
+    <% else %>
+      <li class="nav-item">
+        <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-link" %>
+      </li>
+    <% end %>
 </nav>


### PR DESCRIPTION
close #94

## 実装内容
- ヘッダーの表示レイアウトを変更
  - 画面幅を縮小時にハンバーガーにしていたのを中止。
 
## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
