### PR TITLE
ユーザーアイコンの選択可能拡張子の制限

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -53,6 +53,7 @@ class ArticlesController < ApplicationController
 
   def destroy
     @article.destroy!
+    @article.images.purge
     redirect_to mypage_path(current_user)
   end
 

--- a/app/views/devise/registrations/profile_edit.html.erb
+++ b/app/views/devise/registrations/profile_edit.html.erb
@@ -12,7 +12,7 @@
 
   <div class="form-group">
     <%= f.label :avatar, "ユーザーアイコン" %>
-    <%= f.file_field :avatar, class: 'form-control' %>
+    <%= f.file_field :avatar, accept: "image/jpeg,image/png,image/jpg", class: 'form-control' %>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
close #96

## 実装内容
- `Active Storage`上でバリテーションを組む予定だったが思うように動作しないので一旦次に進む
  - 今回可能だったのはユーザーアイコンの選択時にフロント側で拡張子の制限をつけるだけとなった。

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
