### PR TITLE
emailカラムに一意性を付与

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :profile, length: { maximum: 200 }
+  validates :email, { uniqueness: { case_sensitive: false } }
 
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|


### PR DESCRIPTION
close #98

## 実装内容
- 登録時のemailに一意制限を追加
  - ゲストログイン時のアドレスと被ると機能制限が出てしまうため

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
