### PR TITLE
ユーザーアイコンサイズの場面ごとの統一

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,10 +27,12 @@ module ApplicationHelper
 
   def user_icon(user, size)
     case size
-    when "medium"
-      user.avatar.variant(resize: "60x60").processed
-    when "small"
-      user.avatar.variant(resize: "50x50").processed
+    when "mypage"
+      user.avatar.variant(resize: "72x72").processed
+    when "header"
+      user.avatar.variant(resize: "32x32").processed
+    when "list"
+      user.avatar.variant(resize: "25x25").processed
     end
   end
 end

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= image_tag user_icon(article.user, "small") %>
+  <%= image_tag user_icon(article.user, "list") %>
   <%= link_to "@#{article.user.name}", mypage_path(article.user.id) %>
   <%= "が#{creation_date(article)}に投稿" %>
   <p>タグ

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,4 +1,4 @@
-<%= image_tag user_icon(@article.user, "small") %>
+<%= image_tag user_icon(@article.user, "list") %>
 <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id) %>
 <%= "が#{update_data(@article)}に更新" %>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,7 +4,7 @@
       <button class="nav-item"><%= link_to "投稿する", new_article_path, class: "nav-link" %></button>
       <div class="dropdown">
         <li class="nav-item dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <%= image_tag user_icon(current_user, "medium") %>
+          <%= image_tag user_icon(current_user, "header") %>
         </li>
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
           <li class="dropdown-item"><%= link_to "マイページ", mypage_path(current_user) %></li>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -1,5 +1,5 @@
 
-<%= image_tag user_icon(@user, "small") %>
+<%= image_tag user_icon(@user, "mypage") %>
 <p><%= "@#{@user.name}" %></p>
 <p><%= "投稿数#{@user.articles.published.count}" %></p>
 


### PR DESCRIPTION
close #100

## 実装内容

- 特定の場所に応じてユーザーアイコンの表示サイズを変更
  - 変更実装は`helper`を使用
  - helper内でのサイズ選択肢とリサイズの大きさを一部変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
