### PR TITLE
font-familyを指定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,10 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 @import "@fortawesome/fontawesome-free/scss/regular";
 
 /* 全体 */
+body {
+  font-family: "Helvetica Neue", "Helvetica", "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "Arial", "Yu Gothic", "Meiryo", sans-serif;
+}
 
 .base-container {
   margin: 0 auto;


### PR DESCRIPTION
close #105

## 実装内容
- `Google Fonts`は使用せずに指定
  - データが大きく読み込みを要すので多様は控えた方がよいそうな
  - 現状では下記の参考資料の抜粋を設定している
  - 当PC（macbook, iphone）上でのフォントの変更は確認済み
  - windows, androidの確認はherokuデプロイ時に確認し問題がないか確認する

## 参考資料（必要であれば）
[おすすめのfont-family設定例](https://willcloud.jp/knowhow/font-family/#font-family-4)

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
