### PR TITLE
header部のデザインを変更

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,21 +49,30 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 body {
   font-family: "Helvetica Neue", "Helvetica", "Hiragino Sans",
     "Hiragino Kaku Gothic ProN", "Arial", "Yu Gothic", "Meiryo", sans-serif;
-  padding-top: 60px;
+  padding-top: 80px;
 }
 
 /* header */
 .header {
   background-color: #9ddcdc;
-}
-
-/* 未ログイン時 */
-.user-relation-link {
-  list-style-type: none;
-  .user-relation-text {
-    color: #fff;
+  .header-link {
+    list-style-type: none;
+    .header-text {
+      color: #fff;
+    }
+    .icon {
+      margin-right: 5px;
+    }
+  }
+  .navbar-toggler {
+    border: 4px solid white;
+    border-color: white;
+  }
+  .navbar-toggler-icon {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(255, 255, 255, 1)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='3' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
   }
 }
+
 // フラッシュ
 
 .alert-notice {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,6 +57,13 @@ body {
   background-color: #9ddcdc;
 }
 
+/* 未ログイン時 */
+.user-relation-link {
+  list-style-type: none;
+  .user-relation-text {
+    color: #fff;
+  }
+}
 // フラッシュ
 
 .alert-notice {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,10 +20,6 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 @import "@fortawesome/fontawesome-free/scss/regular";
 
 /* 全体 */
-body {
-  font-family: "Helvetica Neue", "Helvetica", "Hiragino Sans",
-    "Hiragino Kaku Gothic ProN", "Arial", "Yu Gothic", "Meiryo", sans-serif;
-}
 
 .base-container {
   margin: 0 auto;
@@ -51,7 +47,14 @@ body {
 /* body */
 
 body {
+  font-family: "Helvetica Neue", "Helvetica", "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "Arial", "Yu Gothic", "Meiryo", sans-serif;
   padding-top: 60px;
+}
+
+/* header */
+.header {
+  background-color: #9ddcdc;
 }
 
 // フラッシュ

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,27 +1,55 @@
 <nav class="navbar navbar-expand-md fixed-top header">
   <%= link_to "medimo", root_path, class: "navbar-brand" %>
-    <% if user_signed_in? %>
-      <button class="nav-item"><%= link_to "投稿する", new_article_path, class: "nav-link" %></button>
-      <div class="dropdown">
-        <li class="nav-item dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <%= image_tag user_icon(current_user, "header") %>
+
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="collapse navbar-collapse" id="navbarNav">
+    <ul class="navbar-nav ml-auto">
+      <% if user_signed_in? %>
+        <li class="nav-item header-link mr-4">
+          <%= link_to new_article_path, class: "nav-link header-text" do %>
+            <i class="far fa-edit icon"></i>投稿する
+          <% end %>
         </li>
-        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-          <li class="dropdown-item"><%= link_to "マイページ", mypage_path(current_user) %></li>
-          <li class="dropdown-item"><%= link_to "保存記事一覧", mypage_index_path %></li>
-          <li class="dropdown-item"><%= link_to "アカウント編集", edit_user_registration_path %></li>
-          <li class="dropdown-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete %><li>
-        </div>
-      </div>
-    <% else %>
-      <li class="nav-item user-relation-link">
-        <%= link_to "新規登録", new_user_registration_path, class: "nav-link user-relation-text" %>
-      </li>
-      <li class="nav-item user-relation-link">
-        <%= link_to "ログイン", new_user_session_path, class: "nav-link user-relation-text" %>
-      </li>
-      <li class="nav-item user-relation-link">
-        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-link user-relation-text" %>
-      </li>
-    <% end %>
+        <li class="nav-item header-link">
+          <%= link_to mypage_path(current_user), class: "nav-link header-text" do %>
+             <i class="fas fa-user icon"></i>マイページ
+          <% end %>
+        </li>
+        <li class="nav-item header-link">
+          <%= link_to mypage_index_path, class: "nav-link header-text" do %>
+            <i class="fas fa-notes-medical icon"></i>保存した記事
+          <% end %>
+        </li>
+        <li class="nav-item header-link">
+          <%= link_to edit_user_registration_path, class: "nav-link header-text" do %>
+            <i class="fas fa-wrench icon"></i>設定
+          <% end %>
+        </li>
+        <li class="nav-item header-link">
+          <%= link_to destroy_user_session_path, method: :delete, class: "nav-link header-text" do %>
+            <i class="fas fa-sign-out-alt icon"></i>ログアウト
+          <% end %>
+        <li>
+      <% else %>
+        <li class="nav-item header-link">
+          <%= link_to new_user_registration_path, class: "nav-link header-text" do %>
+            <i class="fas fa-user-plus icon"></i>新規登録
+          <% end %>
+        </li>
+        <li class="nav-item header-link">
+          <%= link_to new_user_session_path, class: "nav-link header-text" do %>
+            <i class="fas fa-sign-in-alt icon"></i>ログイン
+          <% end %>
+        </li>
+        <li class="nav-item header-link">
+          <%= link_to users_guest_sign_in_path, method: :post, class: "nav-link header-text" do %>
+            <i class="fas fa-id-card icon"></i>ゲストログイン
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
 </nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md navbar-light bg-light fixed-top">
+<nav class="navbar navbar-expand-md fixed-top header">
   <%= link_to "medimo", root_path, class: "navbar-brand" %>
     <% if user_signed_in? %>
       <button class="nav-item"><%= link_to "投稿する", new_article_path, class: "nav-link" %></button>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -14,14 +14,14 @@
         </div>
       </div>
     <% else %>
-      <li class="nav-item">
-        <%= link_to "新規登録", new_user_registration_path, class: "nav-link" %>
+      <li class="nav-item user-relation-link">
+        <%= link_to "新規登録", new_user_registration_path, class: "nav-link user-relation-text" %>
       </li>
-      <li class="nav-item">
-        <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
+      <li class="nav-item user-relation-link">
+        <%= link_to "ログイン", new_user_session_path, class: "nav-link user-relation-text" %>
       </li>
-      <li class="nav-item">
-        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-link" %>
+      <li class="nav-item user-relation-link">
+        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-link user-relation-text" %>
       </li>
     <% end %>
 </nav>


### PR DESCRIPTION
close #108

## 実装内容
- ヘッダーのデザインを変更
  - 主な仕様は #108 と同様
  - その他の変更点
    - `header`各リンクにアイコンを設置
    - ハンバーガーメニューを復活させてユーザーアイコン内でのドロップダウン表示を変更
    - collapseにまとめたことで視認性が良くなった。
    - ハンバーガーメニューのデザインの変更(色・枠のサイズ)

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
