### PR TITLE
アプリ内のフォーム・ボタンのデザインを変更

### DIFF
--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -8,7 +8,9 @@
 // We need to override trix.css’s image gallery styles to accommodate the
 // <action-text-attachment> element we wrap around attachments. Otherwise,
 // images in galleries will be squished by the max-width: 33%; rule.
+@import "application.scss";
 .trix-content {
+  border: 1px solid $main-color;
   .attachment-gallery {
     > action-text-attachment,
     > .attachment {

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -8,9 +8,7 @@
 // We need to override trix.css’s image gallery styles to accommodate the
 // <action-text-attachment> element we wrap around attachments. Otherwise,
 // images in galleries will be squished by the max-width: 33%; rule.
-@import "application.scss";
 .trix-content {
-  border: 1px solid $main-color;
   .attachment-gallery {
     > action-text-attachment,
     > .attachment {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -132,6 +132,20 @@ body {
   letter-spacing: 0.5em;
 }
 
+/* devise関連のボタン */
+.devise-main-button {
+  background-color: $main-color;
+  color: #fff;
+}
+.devise-negative-button {
+  background-color: #e67a7a;
+  color: #fff;
+}
+.devise-other-button {
+  background-color: #847f7d;
+  color: #fff;
+}
+
 // フラッシュ
 
 .alert-notice {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -113,6 +113,13 @@ body {
 .user-icon {
   border-radius: 50%;
 }
+
+/* _form */
+.form {
+  border: 1px solid $main-color;
+  height: 50px;
+}
+
 // フラッシュ
 
 .alert-notice {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -119,6 +119,18 @@ body {
   border: 1px solid $main-color;
   height: 50px;
 }
+.post-button {
+  margin-top: 10px;
+  // width: 90px;
+  width: 100%;
+  height: 50px;
+  color: #fff;
+  background-color: $main-color;
+  border: 1px solid $main-color;
+  border-radius: 10px;
+  font-weight: bold;
+  letter-spacing: 0.5em;
+}
 
 // フラッシュ
 

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,16 +1,18 @@
-<%= form_with model: @article, local: true do |f| %>
-  <p>
-    <%= f.label :title, class:"form-label"  %>
-    <%= f.text_field :title, placeholder: "タイトル", required: true, class:"form-control form" %>
-  </p>
-  <p>
-    <%= f.label :tag_name, class:"form-label" %>
-    <%= f.text_field :tag_name, value: @tag_list, placeholder: "スペース区切りで入力 (例: 外科 手術)", class:"form-control form" %>
-  </p>
-  <p>
-    <%= f.label :content %>
-    <%= f.rich_text_area :content, placeholder: "あなたの学びを共有しよう" %>
-  </p>
-  <%= f.select :status, Article.statuses_i18n.invert %>
-  <%= f.submit "送信" %>
-<% end %>
+<div class="form-group">
+  <%= form_with model: @article, local: true do |f| %>
+    <p>
+      <%= f.label :title, class:"form-label"  %>
+      <%= f.text_field :title, placeholder: "タイトル", required: true, class:"form-control form" %>
+    </p>
+    <p>
+      <%= f.label :tag_name, class:"form-label" %>
+      <%= f.text_field :tag_name, value: @tag_list, placeholder: "スペース区切りで入力 (例: 外科 手術)", class:"form-control form" %>
+    </p>
+    <p>
+      <%= f.label :content %>
+      <%= f.rich_text_area :content, placeholder: "あなたの学びを共有しよう" %>
+    </p>
+    <%= f.select :status, Article.statuses_i18n.invert, {}, class: 'form-control form' %>
+    <%= f.submit "投稿", class:"post-button" %>
+  <% end %>
+</div>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,11 +1,11 @@
 <%= form_with model: @article, local: true do |f| %>
   <p>
     <%= f.label :title, class:"form-label"  %>
-    <%= f.text_field :title, placeholder: "タイトル", required: true, class:"form-control" %>
+    <%= f.text_field :title, placeholder: "タイトル", required: true, class:"form-control form" %>
   </p>
   <p>
     <%= f.label :tag_name, class:"form-label" %>
-    <%= f.text_field :tag_name, value: @tag_list, placeholder: "スペース区切りで入力 (例: 外科 手術)", class:"form-control" %>
+    <%= f.text_field :tag_name, value: @tag_list, placeholder: "スペース区切りで入力 (例: 外科 手術)", class:"form-control form" %>
   </p>
   <p>
     <%= f.label :content %>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,11 +1,11 @@
 <%= form_with model: @article, local: true do |f| %>
   <p>
-    <%= f.label :title  %>
-    <%= f.text_field :title, placeholder: "タイトル", required: true %>
+    <%= f.label :title, class:"form-label"  %>
+    <%= f.text_field :title, placeholder: "タイトル", required: true, class:"form-control" %>
   </p>
   <p>
-    <%= f.label :tag_name %>
-    <%= f.text_field :tag_name, value: @tag_list, placeholder: "スペース区切りで入力 (例: 外科 手術)" %>
+    <%= f.label :tag_name, class:"form-label" %>
+    <%= f.text_field :tag_name, value: @tag_list, placeholder: "スペース区切りで入力 (例: 外科 手術)", class:"form-control" %>
   </p>
   <p>
     <%= f.label :content %>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,2 +1,2 @@
-<h1>編集</h1>
+<h1 class="text-center">編集</h1>
 <%= render "form" %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,2 +1,2 @@
-<h1>新規投稿</h1>
+<h1 class="text-center">新規投稿</h1>
 <%= render "form" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,35 +5,35 @@
 
   <div class="form-group">
     <%= f.label :email %>
-    <%= f.email_field :email, autocomplete: 'email', class: 'form-control' %>
+    <%= f.email_field :email, autocomplete: 'email', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
     <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
+    <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control form' %>
 
     <small class="form-text text-muted"><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></small>
   </div>
 
   <div class="form-group">
     <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control'  %>
+    <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control form'  %>
   </div>
 
   <div class="form-group">
     <%= f.label :current_password %>
-    <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
+    <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control form' %>
 
     <small class="form-text text-muted"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></small>
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.update'), class: 'btn btn-primary btn-block' %>
+    <%= f.submit t('.update'), class: 'btn btn-block devise-main-button' %>
   </div>
 <% end %>
 
 <hr class="my-5">
 
-<p><%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-danger btn-block" %></p>
+<p><%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-block devise-negative-button" %></p>
 
-<%= link_to "戻る", :back, class: "btn btn-secondary btn-block" %>
+<%= link_to "戻る", :back, class: "btn btn-block devise-other-button" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,17 +5,17 @@
 
   <div class="form-group">
     <%= f.label :name %>
-    <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control' %>
+    <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
     <%= f.label :email %>
-    <%= f.email_field :email, autocomplete: 'email', class: 'form-control' %>
+    <%= f.email_field :email, autocomplete: 'email', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
     <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
+    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control form' %>
     <% if @minimum_password_length %>
       <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
     <% end %>
@@ -23,11 +23,11 @@
 
   <div class="form-group">
     <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control' %>
+    <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.sign_up'), class: 'btn btn-primary btn-block' %>
+    <%= f.submit t('.sign_up'), class: 'btn btn-block devise-main-button' %>
   </div>
 <% end %>
 <%= render 'devise/shared/links' %>

--- a/app/views/devise/registrations/profile_edit.html.erb
+++ b/app/views/devise/registrations/profile_edit.html.erb
@@ -2,20 +2,20 @@
 
   <div class="form-group">
     <%= f.label :name %>
-    <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control' %>
+    <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
     <%= f.label :profile %>
-    <%= f.text_area :profile, class: 'form-control' %>
+    <%= f.text_area :profile, class: 'form-control form', style:"height:200px"%>
   </div>
 
   <div class="form-group">
     <%= f.label :avatar, "ユーザーアイコン" %>
-    <%= f.file_field :avatar, accept: "image/jpeg,image/png,image/jpg", class: 'form-control' %>
+    <%= f.file_field :avatar, accept: "image/jpeg,image/png,image/jpg", class: 'form-control form' %>
   </div>
 
   <div class="form-group">
-    <%= f.submit "更新", class: 'btn btn-primary btn-block' %>
+    <%= f.submit "更新", class: 'btn btn-block devise-main-button' %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,12 +3,12 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-group">
     <%= f.label :email %>
-    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
     <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
+    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control form' %>
   </div>
 
   <% if devise_mapping.rememberable? %>
@@ -21,7 +21,7 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.submit  t('.sign_in'), class: 'btn btn-primary btn-block' %>
+    <%= f.submit  t('.sign_in'), class: 'btn btn-block devise-main-button' %>
   </div>
 <% end %>
 <%= render 'devise/shared/links' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,10 +1,10 @@
 <div class="form-group">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name), class: "btn btn-secondary btn-block" %><br />
+    <%= link_to t(".sign_in"), new_session_path(resource_name), class: "btn btn-block devise-other-button" %><br />
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= link_to t(".sign_up"), new_registration_path(resource_name), class: "btn btn-secondary btn-block" %><br />
+    <%= link_to t(".sign_up"), new_registration_path(resource_name), class: "btn btn-block devise-other-button" %><br />
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -3,7 +3,7 @@
 <p><%= "@#{@user.name}" %></p>
 <p><%= "投稿数#{@user.articles.published.count}" %></p>
 
-<%= @user.profile %>
+<%= simple_format(@user.profile) %>
 <% if user_signed_in? && account_owner?(@user) %>
   <h3><%= link_to "プロフィール編集", profile_edit_path %></h3>
 


### PR DESCRIPTION
close #112

## 実装内容
- アプリ内のフォーム・ボタンのデザインを変更
  -  devise関連
     - ログイン・新規登録
     - プロフィール編集・アカウント設定
     - プロフィール文章の改行反映がされていなかったので反映
  - Article関連
    - 作成・編集時のフォームデザインの変更
   
## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
