### PR TITLE
記事詳細ページのデザイン変更

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,0 +1,7 @@
+$main-color: #9ddcdc;
+$accent-color: #e67a7a;
+$other-color: #847f7d;
+
+$main-background-color: #fff4e1;
+$article-list-color: #f8f8f8;
+$article-list-border-color: #cac8c8;

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -8,7 +8,9 @@
 // We need to override trix.css’s image gallery styles to accommodate the
 // <action-text-attachment> element we wrap around attachments. Otherwise,
 // images in galleries will be squished by the max-width: 33%; rule.
+@import "variables.scss";
 .trix-content {
+  background-color: $article-list-color;
   .attachment-gallery {
     > action-text-attachment,
     > .attachment {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,9 +18,8 @@
 $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 @import "@fortawesome/fontawesome-free/scss/fontawesome";
 @import "@fortawesome/fontawesome-free/scss/regular";
-
+@import "variables";
 /* ベースカラー */
-$main-color: #9ddcdc;
 /* 全体 */
 
 .base-container {
@@ -67,7 +66,7 @@ a:hover {
 body {
   font-family: "Helvetica Neue", "Helvetica", "Hiragino Sans",
     "Hiragino Kaku Gothic ProN", "Arial", "Yu Gothic", "Meiryo", sans-serif;
-  background-color: #fff4e1;
+  background-color: $main-background-color;
   padding-top: 80px;
 }
 
@@ -99,9 +98,9 @@ body {
 
 /* _article */
 .article {
-  background-color: rgb(248, 248, 248);
-  border-top: 1px solid rgb(202, 200, 200);
-  border-bottom: 1px solid rgb(202, 200, 200);
+  background-color: $article-list-color;
+  border-top: 1px solid $article-list-border-color;
+  border-bottom: 1px solid $article-list-border-color;
   margin: 0 0 -1px;
   padding: 16px 16px 0px 16px;
   width: 100%;
@@ -109,7 +108,7 @@ body {
     display: flex;
     justify-content: space-between;
     .like-icon {
-      color: #e67a7a;
+      color: $accent-color;
       font-size: 2rem;
       margin-right: 0.5rem;
     }
@@ -131,7 +130,6 @@ body {
 }
 .post-button {
   margin-top: 10px;
-  // width: 90px;
   width: 100%;
   height: 50px;
   color: #fff;
@@ -143,16 +141,16 @@ body {
 }
 
 /* devise関連のボタン */
-.devise-main-button {
+.main-btn {
   background-color: $main-color;
   color: #fff;
 }
-.devise-negative-button {
-  background-color: #e67a7a;
+.negative-btn {
+  background-color: $accent-color;
   color: #fff;
 }
-.devise-other-button {
-  background-color: #847f7d;
+.other-btn {
+  background-color: $other-color;
   color: #fff;
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,9 +28,21 @@ $main-color: #9ddcdc;
   padding: 1rem;
 }
 
-.erb-link {
+a:hover {
   text-decoration: none;
+}
+
+.erb-link {
   color: black;
+  &:hover {
+    color: black;
+  }
+}
+.erb-link-btn {
+  color: #fff;
+  &:hover {
+    color: #fff;
+  }
 }
 /* max-width */
 
@@ -98,13 +110,11 @@ body {
     justify-content: space-between;
     .like-icon {
       color: #e67a7a;
-      font-size: 20px;
-      margin-right: 8px;
+      font-size: 2rem;
+      margin-right: 0.5rem;
     }
-    .keep,
-    .dont-keep {
-      font-size: 40px;
-      transform: translateY(-40px);
+    .keep-icon {
+      font-size: 2.5rem;
       color: $main-color;
     }
   }

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1,22 +1,21 @@
-// Place all the styles related to the Articles controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+@import "variables.scss";
+
 .article-show {
-  background-color: rgb(248, 248, 248);
+  background-color: $article-list-color;
   padding: 1rem;
 }
 
 .reaction {
   margin-top: 1rem;
-  background-color: rgb(248, 248, 248);
+  background-color: $article-list-color;
   display: flex;
   justify-content: space-between;
 
   .like-icon {
-    color: #e67a7a;
+    color: $accent-color;
     margin: 0 0.5rem;
     &:hover {
-      text-decoration-color: rgb(248, 248, 248);
+      text-decoration-color: $article-list-color;
     }
   }
   .like-count {
@@ -24,7 +23,7 @@
   }
   .keep-icon {
     margin: 0 0.5rem;
-    color: #9ddcdc;
+    color: $main-color;
   }
   .keep-icon,
   .like-icon {
@@ -43,7 +42,7 @@
 }
 
 .modal-header {
-  background-color: #7ec2c2;
+  background-color: $main-color;
   color: #fff;
   .close {
     color: #fff;
@@ -51,6 +50,6 @@
 }
 .modal-body,
 .modal-footer {
-  background-color: #fff4e1;
+  background-color: $main-background-color;
   border: none;
 }

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -1,3 +1,47 @@
 // Place all the styles related to the Articles controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+.article-show {
+  background-color: rgb(248, 248, 248);
+  padding: 1rem;
+}
+
+.reaction {
+  margin-top: 1rem;
+  background-color: rgb(248, 248, 248);
+  display: flex;
+  justify-content: space-between;
+
+  .like-icon {
+    color: #e67a7a;
+    margin: 0 0.5rem;
+    &:hover {
+      text-decoration-color: rgb(248, 248, 248);
+    }
+  }
+  .like-count {
+    font-size: 1.5rem;
+  }
+  .keep-icon {
+    margin: 0 0.5rem;
+    color: #9ddcdc;
+  }
+  .keep-icon,
+  .like-icon {
+    padding-top: 0.5rem;
+    font-size: 2.5rem;
+  }
+}
+
+.modal-header {
+  background-color: #7ec2c2;
+  color: #fff;
+  .close {
+    color: #fff;
+  }
+}
+.modal-body,
+.modal-footer {
+  background-color: #fff4e1;
+  border: none;
+}

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -31,6 +31,15 @@
     padding-top: 0.5rem;
     font-size: 2.5rem;
   }
+  .author {
+    margin: 1.5rem 0.5rem 0 0;
+    a:hover {
+      color: #fff;
+    }
+    .edit-icon {
+      margin-right: 5px;
+    }
+  }
 }
 
 .modal-header {

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -31,14 +31,14 @@
     padding-top: 0.5rem;
     font-size: 2.5rem;
   }
-  .author {
-    margin: 1.5rem 0.5rem 0 0;
-    a:hover {
-      color: #fff;
-    }
-    .edit-icon {
-      margin-right: 5px;
-    }
+}
+.author {
+  margin: 1.5rem 0.5rem 0 0;
+  a:hover {
+    color: #fff;
+  }
+  .edit-icon {
+    margin-right: 5px;
   }
 }
 

--- a/app/views/articles/_dislike.html.erb
+++ b/app/views/articles/_dislike.html.erb
@@ -1,4 +1,6 @@
 <%= link_to article_likes_path(article), method: :post, remote: true do %>
-  <i class="far fa-heart"></i>
+  <i class="far fa-heart like-icon"></i>
 <% end %>
-<%= article.likes_count %>
+<span class="like-count">
+  <%= article.likes_count %>
+</span>

--- a/app/views/articles/_dont_keep.html.erb
+++ b/app/views/articles/_dont_keep.html.erb
@@ -1,3 +1,3 @@
 <%= link_to article_keeps_path(article), method: :post, remote: true do %>
-  <i class="far fa-clipboard dont-keep"></i>
+  <i class="far fa-clipboard keep-icon"></i>
 <% end %>

--- a/app/views/articles/_keep.html.erb
+++ b/app/views/articles/_keep.html.erb
@@ -1,3 +1,3 @@
 <%= link_to article_keeps_path(article), method: :delete, remote: true do %>
-  <i class="fas fa-notes-medical dont-keep"></i>
+  <i class="fas fa-notes-medical keep-icon"></i>
 <% end %>

--- a/app/views/articles/_like.html.erb
+++ b/app/views/articles/_like.html.erb
@@ -1,4 +1,6 @@
 <%= link_to article_likes_path(article), method: :delete, remote: true do %>
-  <i class="fas fa-heart"></i>
+  <i class="fas fa-heart like-icon"></i>
 <% end %>
-<%= article.likes_count %>
+<span class="like-count">
+  <%= article.likes_count %>
+</span>

--- a/app/views/articles/_non_member.html.erb
+++ b/app/views/articles/_non_member.html.erb
@@ -1,10 +1,14 @@
 <div data-toggle="modal" data-target="#exampleModal">
-  <button type="button" class="btn btn-primary">
-    いいね
-  </button>
-  <button type="button" class="btn btn-primary">
-    保存
-  </button>
+  <div class="reaction">
+  <p>
+    <div class="like-icon">
+      <i class="far fa-heart like-icon"></i>
+    </div>
+    <div class="keep-icon">
+      <i class="far fa-clipboard keep-icon"></i>
+    </div>
+  </p>
+  </div>
 </div>
 
 <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
@@ -20,8 +24,8 @@
         <p>この機能を利用するにはログインする必要があります</p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-success"><%= link_to "登録する", new_user_registration_path, class:"erb-link" %></button>
-        <button type="button" class="btn btn-primary"><%= link_to "ログイン", new_user_session_path, class:"erb-link" %></button>
+        <button type="button" class="btn devise-main-button "><%= link_to "登録する", new_user_registration_path, class:"erb-link-btn" %></button>
+        <button type="button" class="btn devise-main-button "><%= link_to "ログイン", new_user_session_path, class:"erb-link-btn" %></button>
       </div>
     </div>
   </div>

--- a/app/views/articles/_non_member.html.erb
+++ b/app/views/articles/_non_member.html.erb
@@ -24,8 +24,8 @@
         <p>この機能を利用するにはログインする必要があります</p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn devise-main-button "><%= link_to "登録する", new_user_registration_path, class:"erb-link-btn" %></button>
-        <button type="button" class="btn devise-main-button "><%= link_to "ログイン", new_user_session_path, class:"erb-link-btn" %></button>
+        <button type="button" class="btn main-btn "><%= link_to "登録する", new_user_registration_path, class:"erb-link-btn" %></button>
+        <button type="button" class="btn main-btn "><%= link_to "ログイン", new_user_session_path, class:"erb-link-btn" %></button>
       </div>
     </div>
   </div>

--- a/app/views/articles/closes/show.html.erb
+++ b/app/views/articles/closes/show.html.erb
@@ -1,4 +1,19 @@
-<h1><%= @article.title %></h1>
-<%= render "articles/tags" %>
-<%= @article.content %>
-<%= link_to "編集", edit_article_path(@article) %>
+<div class="article-show mw-md mx-auto">
+  <h1><%= @article.title %></h1>
+  <p>
+    <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
+    <%= "が#{update_data(@article)}に更新" %>
+  </p>
+  <p><i class="fas fa-tags"></i>
+    <%= render "articles/tags" %>
+  </p>
+  <%= @article.content %>
+  <div class="author">
+    <%= link_to edit_article_path(@article), class:"btn devise-main-button" do %>
+      <i class="fas fa-pen edit-icon"></i>編集
+    <% end %>
+    <%= link_to "#", class:"btn devise-negative-button" do %>
+          <i class="fas fa-trash-alt edit-icon"></i>削除
+    <% end %>
+  </div>
+</div>

--- a/app/views/articles/closes/show.html.erb
+++ b/app/views/articles/closes/show.html.erb
@@ -9,10 +9,10 @@
   </p>
   <%= @article.content %>
   <div class="author">
-    <%= link_to edit_article_path(@article), class:"btn devise-main-button" do %>
+    <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
       <i class="fas fa-pen edit-icon"></i>編集
     <% end %>
-    <%= link_to "#", class:"btn devise-negative-button" do %>
+    <%= link_to "#", class:"btn negative-btn" do %>
           <i class="fas fa-trash-alt edit-icon"></i>削除
     <% end %>
   </div>

--- a/app/views/articles/drafts/show.html.erb
+++ b/app/views/articles/drafts/show.html.erb
@@ -1,3 +1,9 @@
-<%= @article.title %>
-<%= @article.content %>
-<%= link_to "編集", edit_article_path(@article) %>
+<div class="article-show mw-md mx-auto">
+  <h1><%= @article.title %></h1>
+  <%= @article.content %>
+  <div class="author">
+    <%= link_to edit_article_path(@article), class:"btn devise-main-button" do %>
+      <i class="fas fa-pen edit-icon"></i>編集
+    <% end %>
+  </div>
+</div>

--- a/app/views/articles/drafts/show.html.erb
+++ b/app/views/articles/drafts/show.html.erb
@@ -2,10 +2,10 @@
   <h1><%= @article.title %></h1>
   <%= @article.content %>
   <div class="author">
-    <%= link_to edit_article_path(@article), class:"btn devise-main-button" do %>
+    <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
       <i class="fas fa-pen edit-icon"></i>編集
     <% end %>
-     <%= link_to "#", class:"btn devise-negative-button" do %>
+     <%= link_to "#", class:"btn negative-btn" do %>
           <i class="fas fa-trash-alt edit-icon"></i>削除
     <% end %>
   </div>

--- a/app/views/articles/drafts/show.html.erb
+++ b/app/views/articles/drafts/show.html.erb
@@ -5,5 +5,8 @@
     <%= link_to edit_article_path(@article), class:"btn devise-main-button" do %>
       <i class="fas fa-pen edit-icon"></i>編集
     <% end %>
+     <%= link_to "#", class:"btn devise-negative-button" do %>
+          <i class="fas fa-trash-alt edit-icon"></i>削除
+    <% end %>
   </div>
 </div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -36,10 +36,10 @@
   <% end %>
   <div class="author">
     <% if author?(@article) %>
-        <%= link_to edit_article_path(@article), class:"btn devise-main-button" do %>
+        <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
           <i class="fas fa-pen edit-icon"></i>編集
         <% end %>
-        <%= link_to article_path(@article), method: :delete, data: { confirm: "削除しますか？" }, class:"btn devise-negative-button" do %>
+        <%= link_to article_path(@article), method: :delete, data: { confirm: "削除しますか？" }, class:"btn negative-btn" do %>
           <i class="fas fa-trash-alt edit-icon"></i>削除
         <% end %>
     <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -34,11 +34,14 @@
   <% else %>
     <%= render "non_member"%>
   <% end %>
+  <div class="author">
+    <% if author?(@article) %>
+        <%= link_to edit_article_path(@article), class:"btn devise-main-button" do %>
+          <i class="fas fa-pen edit-icon"></i>編集
+        <% end %>
+        <%= link_to article_path(@article), method: :delete, data: { confirm: "削除しますか？" }, class:"btn devise-negative-button" do %>
+          <i class="fas fa-trash-alt edit-icon"></i>削除
+        <% end %>
+    <% end %>
+  </div>
 </div>
-
-  <% if author?(@article) %>
-    <p>
-      <%= link_to "編集", edit_article_path(@article) %>
-      <%= link_to "削除", article_path(@article), method: :delete, data: { confirm: "削除しますか？" } %>
-    </p>
-  <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -4,7 +4,7 @@
   <%= "が#{update_data(@article)}に更新" %>
 
   <h1><%= @article.title %></h1>
-  <p>タグ
+  <p><i class="fas fa-tags"></i>
     <%= render "tags" %>
   </p>
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,38 +1,44 @@
-<%= image_tag user_icon(@article.user, "list"), class:"user-icon" %>
-<%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
-<%= "が#{update_data(@article)}に更新" %>
+<div class="article-show">
+  <%= image_tag user_icon(@article.user, "list"), class:"user-icon" %>
+  <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
+  <%= "が#{update_data(@article)}に更新" %>
 
-<h1><%= @article.title %></h1>
-<p>タグ
-  <%= render "tags" %>
-</p>
-
-<%= @article.content %>
-
-<% if user_signed_in? %>
-  <p id="article-like-<%= @article.id %>">
-    <% if @article.liked_by?(current_user) %>
-      <%= render "like", article: @article %>
-    <% else %>
-      <%= render "dislike", article: @article %>
-    <% end %>
+  <h1><%= @article.title %></h1>
+  <p>タグ
+    <%= render "tags" %>
   </p>
 
-  <p id="article-keep-<%= @article.id %>">
-    <% if @article.kept_by?(current_user) %>
-      <%= render "keep", article: @article %>
-    <% else %>
-      <%= render "dont_keep", article: @article %>
-    <% end %>
-  </p>
-<% else %>
-  <%= render "non_member"%>
-<% end %>
+  <%= @article.content %>
+</div>
 
-<% if author?(@article) %>
-  <p>
-    <%= link_to "編集", edit_article_path(@article) %>
-    <%= link_to "削除", article_path(@article), method: :delete, data: { confirm: "削除しますか？" } %>
-  </p>
-<% end %>
-<%= link_to "投稿一覧へ", root_path, class:"erb-link" %>
+<div class="reaction">
+  <% if user_signed_in? %>
+    <div class="like-icon">
+      <p id="article-like-<%= @article.id %>">
+        <% if @article.liked_by?(current_user) %>
+          <%= render "like", article: @article %>
+        <% else %>
+          <%= render "dislike", article: @article %>
+        <% end %>
+      </p>
+    </div>
+    <div class="keep-icon">
+      <p id="article-keep-<%= @article.id %>">
+        <% if @article.kept_by?(current_user) %>
+          <%= render "keep", article: @article %>
+        <% else %>
+          <%= render "dont_keep", article: @article %>
+        <% end %>
+      </p>
+    </div>
+  <% else %>
+    <%= render "non_member"%>
+  <% end %>
+</div>
+
+  <% if author?(@article) %>
+    <p>
+      <%= link_to "編集", edit_article_path(@article) %>
+      <%= link_to "削除", article_path(@article), method: :delete, data: { confirm: "削除しますか？" } %>
+    </p>
+  <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,12 +28,12 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.update'), class: 'btn btn-block devise-main-button' %>
+    <%= f.submit t('.update'), class: 'btn btn-block main-btn' %>
   </div>
 <% end %>
 
 <hr class="my-5">
 
-<p><%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-block devise-negative-button" %></p>
+<p><%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-block negative-btn" %></p>
 
-<%= link_to "戻る", :back, class: "btn btn-block devise-other-button" %>
+<%= link_to "戻る", :back, class: "btn btn-block other-btn" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,7 +27,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.sign_up'), class: 'btn btn-block devise-main-button' %>
+    <%= f.submit t('.sign_up'), class: 'btn btn-block main-btn' %>
   </div>
 <% end %>
 <%= render 'devise/shared/links' %>

--- a/app/views/devise/registrations/profile_edit.html.erb
+++ b/app/views/devise/registrations/profile_edit.html.erb
@@ -16,6 +16,6 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "更新", class: 'btn btn-block devise-main-button' %>
+    <%= f.submit "更新", class: 'btn btn-block main-btn' %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -21,7 +21,7 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.submit  t('.sign_in'), class: 'btn btn-block devise-main-button' %>
+    <%= f.submit  t('.sign_in'), class: 'btn btn-block main-btn' %>
   </div>
 <% end %>
 <%= render 'devise/shared/links' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,10 +1,10 @@
 <div class="form-group">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name), class: "btn btn-block devise-other-button" %><br />
+    <%= link_to t(".sign_in"), new_session_path(resource_name), class: "btn btn-block other-btn" %><br />
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= link_to t(".sign_up"), new_registration_path(resource_name), class: "btn btn-block devise-other-button" %><br />
+    <%= link_to t(".sign_up"), new_registration_path(resource_name), class: "btn btn-block other-btn" %><br />
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>


### PR DESCRIPTION
close #114

## 実装内容
- [ 公開・下書き・非公開 ]記事の詳細ページのデザインを変更
- 非ログイン時の詳細ページのデザインも変更
- 「編集・削除」リンクをボタンに変更
- 多用する色については変数専用のファイルを作成し使用時`import`して使うように変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
