### PR TITLE
下書き・非公開記事の削除機能の実装

### DIFF
--- a/app/controllers/articles/closes_controller.rb
+++ b/app/controllers/articles/closes_controller.rb
@@ -15,7 +15,6 @@ class Articles::ClosesController < ApplicationController
     redirect_to mypage_path(current_user)
   end
 
-
   private
 
     def closed_owner

--- a/app/controllers/articles/closes_controller.rb
+++ b/app/controllers/articles/closes_controller.rb
@@ -1,14 +1,20 @@
 class Articles::ClosesController < ApplicationController
-  before_action :closed_owner, only: [:show]
-  before_action :authenticate_user!, only: %i[index show]
+  before_action :closed_owner, only: [:show, :destroy]
+  before_action :authenticate_user!, only: [:index, :show]
   def index
     @closed_articles = current_user.articles.closed.order(updated_at: :desc)
   end
 
   def show
-    @article = current_user.articles.closed.find(params[:id])
     @article_tags = @article.tags
   end
+
+  def destroy
+    @article.destroy!
+    @article.images.purge
+    redirect_to mypage_path(current_user)
+  end
+
 
   private
 

--- a/app/controllers/articles/drafts_controller.rb
+++ b/app/controllers/articles/drafts_controller.rb
@@ -16,6 +16,7 @@ class Articles::DraftsController < ApplicationController
   end
 
   private
+
     def draft_owner
       @article = current_user.articles.draft.find_by(id: params[:id])
       unless @article

--- a/app/controllers/articles/drafts_controller.rb
+++ b/app/controllers/articles/drafts_controller.rb
@@ -1,5 +1,5 @@
 class Articles::DraftsController < ApplicationController
-  before_action :draft_owner, only: [:show]
+  before_action :draft_owner, only: [:show, :destroy]
   before_action :authenticate_user!, only: %i[index show]
 
   def index
@@ -7,11 +7,15 @@ class Articles::DraftsController < ApplicationController
   end
 
   def show
-    @article = current_user.articles.draft.find(params[:id])
+  end
+
+  def destroy
+    @article.destroy!
+    @article.images.purge
+    redirect_to mypage_path(current_user)
   end
 
   private
-
     def draft_owner
       @article = current_user.articles.draft.find_by(id: params[:id])
       unless @article

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,5 +1,5 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
-  <%= image_tag blob.variant(resize: "300x300").processed if blob.representable?%>
+  <%= image_tag blob.variant(resize: "600").processed if blob.representable?%>
 
   <figcaption class="attachment__caption">
     <% if caption = blob.try(:caption) %>

--- a/app/views/articles/closes/show.html.erb
+++ b/app/views/articles/closes/show.html.erb
@@ -12,7 +12,7 @@
     <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
       <i class="fas fa-pen edit-icon"></i>編集
     <% end %>
-    <%= link_to "#", class:"btn negative-btn" do %>
+    <%= link_to articles_close_path(@article), method: :delete, data: { confirm: "削除しますか？" }, class:"btn negative-btn" do %>
           <i class="fas fa-trash-alt edit-icon"></i>削除
     <% end %>
   </div>

--- a/app/views/articles/drafts/show.html.erb
+++ b/app/views/articles/drafts/show.html.erb
@@ -5,8 +5,8 @@
     <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
       <i class="fas fa-pen edit-icon"></i>編集
     <% end %>
-     <%= link_to "#", class:"btn negative-btn" do %>
-          <i class="fas fa-trash-alt edit-icon"></i>削除
+    <%= link_to articles_draft_path(@article), method: :delete, data: { confirm: "削除しますか？" }, class:"btn negative-btn" do %>
+        <i class="fas fa-trash-alt edit-icon"></i>削除
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
   end
 
   namespace :articles do
-    resources :drafts, only: [:index, :show]
-    resources :closes, only: [:index, :show]
+    resources :drafts, only: [:index, :show, :destroy]
+    resources :closes, only: [:index, :show, :destroy]
   end
 
   resources :articles do


### PR DESCRIPTION
close #116

## 実装内容
- 下書き・非公開記事の詳細ページで削除機能を実装

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
