### PR TITLE
記事詳細ページにプロフィールを表示

### DIFF
--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -4,9 +4,13 @@
   background-color: $article-list-color;
   padding: 1rem;
 }
+.user-profile {
+  background-color: $article-list-color;
+  margin-top: 1.5rem;
+  padding: 1rem;
+}
 
 .reaction {
-  margin-top: 1rem;
   background-color: $article-list-color;
   display: flex;
   justify-content: space-between;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,6 +29,8 @@ module ApplicationHelper
     case size
     when "mypage"
       user.avatar.variant(resize: "72x72").processed
+    when "profile"
+      user.avatar.variant(resize: "64x64").processed
     when "header"
       user.avatar.variant(resize: "32x32").processed
     when "list"

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,5 +1,5 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
-  <%= image_tag blob.variant(resize: "600").processed if blob.representable?%>
+  <%= image_tag blob.variant(resize: "500x500").processed if blob.representable?%>
 
   <figcaption class="attachment__caption">
     <% if caption = blob.try(:caption) %>

--- a/app/views/articles/closes/show.html.erb
+++ b/app/views/articles/closes/show.html.erb
@@ -8,7 +8,7 @@
     <%= render "articles/tags" %>
   </p>
   <%= @article.content %>
-  <div class="author">
+  <div class="author d-flex justify-content-end">
     <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
       <i class="fas fa-pen edit-icon"></i>編集
     <% end %>

--- a/app/views/articles/drafts/show.html.erb
+++ b/app/views/articles/drafts/show.html.erb
@@ -1,7 +1,7 @@
 <div class="article-show mw-md mx-auto">
   <h1><%= @article.title %></h1>
   <%= @article.content %>
-  <div class="author">
+  <div class="author d-flex justify-content-end">
     <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
       <i class="fas fa-pen edit-icon"></i>編集
     <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -34,14 +34,21 @@
   <% else %>
     <%= render "non_member"%>
   <% end %>
-  <div class="author">
-    <% if author?(@article) %>
-        <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
-          <i class="fas fa-pen edit-icon"></i>編集
-        <% end %>
-        <%= link_to article_path(@article), method: :delete, data: { confirm: "削除しますか？" }, class:"btn negative-btn" do %>
-          <i class="fas fa-trash-alt edit-icon"></i>削除
-        <% end %>
-    <% end %>
-  </div>
+</div>
+
+<div class="user-profile">
+  <%= image_tag user_icon(@article.user, "profile"), class:"user-icon" %>
+  <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
+  <p><%= simple_format(@article.user.profile)%></p>
+</div>
+
+<div class="author float-right">
+  <% if author?(@article) %>
+      <%= link_to edit_article_path(@article), class:"btn main-btn" do %>
+        <i class="fas fa-pen edit-icon"></i>編集
+      <% end %>
+      <%= link_to article_path(@article), method: :delete, data: { confirm: "削除しますか？" }, class:"btn negative-btn" do %>
+        <i class="fas fa-trash-alt edit-icon"></i>削除
+      <% end %>
+  <% end %>
 </div>


### PR DESCRIPTION
close #118

## 実装内容
- 記事詳細ページに執筆者のプロフィールを表示
  - これに伴い一部レイアウトを調整
- 下書き・非公開記事の「削除・編集」ボタンの場所を変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
