### PR TITLE
マイページのデザインを変更

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,4 +1,5 @@
 $main-color: #9ddcdc;
+$sub-color: #7ec2c2;
 $accent-color: #e67a7a;
 $other-color: #847f7d;
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -164,3 +164,23 @@ body {
   @extend .alert-danger;
   margin-top: -5px;
 }
+
+/* ページネーション */
+.page-item.active .page-link {
+  background: $sub-color;
+  border-color: $sub-color;
+}
+.pagination {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  li {
+    a {
+      color: $main-color;
+      &:hover {
+        background-color: $main-color;
+        color: #fff;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -139,7 +139,7 @@ body {
   letter-spacing: 0.5em;
 }
 
-/* devise関連のボタン */
+/* ボタン */
 .main-btn {
   background-color: $main-color;
   color: #fff;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,9 +19,8 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 @import "@fortawesome/fontawesome-free/scss/fontawesome";
 @import "@fortawesome/fontawesome-free/scss/regular";
 @import "variables";
-/* ベースカラー */
-/* 全体 */
 
+/* 全体 */
 .base-container {
   margin: 0 auto;
   padding: 1rem;
@@ -43,8 +42,8 @@ a:hover {
     color: #fff;
   }
 }
-/* max-width */
 
+/* max-width */
 .mw-sm {
   max-width: 576px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,10 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
   padding: 1rem;
 }
 
+.text-center {
+  color: #6c757d;
+}
+
 a:hover {
   text-decoration: none;
 }

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -2,7 +2,7 @@
 
 .search-bar {
   border: 1px solid $main-color;
-  width: 70%;
+  width: 65%;
   height: 50px;
 }
 .search-button {

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -1,3 +1,11 @@
-// Place all the styles related to the mypage controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+@import "variables.scss";
+
+.profile-contener {
+  background-color: $article-list-color;
+  .user-data {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -9,3 +9,15 @@
     align-items: center;
   }
 }
+
+.nav-pills {
+  .nav-item {
+    .nav-link.active {
+      background-color: $main-color;
+    }
+  }
+  .nav-link,
+  &:hover {
+    color: $main-color;
+  }
+}

--- a/app/controllers/articles/closes_controller.rb
+++ b/app/controllers/articles/closes_controller.rb
@@ -2,7 +2,7 @@ class Articles::ClosesController < ApplicationController
   before_action :closed_owner, only: [:show, :destroy]
   before_action :authenticate_user!, only: [:index, :show]
   def index
-    @closed_articles = current_user.articles.closed.order(updated_at: :desc)
+    @closed_articles = current_user.articles.closed.order(updated_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
   def show

--- a/app/controllers/articles/drafts_controller.rb
+++ b/app/controllers/articles/drafts_controller.rb
@@ -3,7 +3,7 @@ class Articles::DraftsController < ApplicationController
   before_action :authenticate_user!, only: %i[index show]
 
   def index
-    @draft_articles = current_user.articles.draft.order(updated_at: :desc)
+    @draft_articles = current_user.articles.draft.order(updated_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
   def show

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -9,7 +9,7 @@ class MypageController < ApplicationController
   def show
     @user = User.with_attached_avatar.find(params[:id])
     @articles = @user.articles.published.includes(:keeps, :tags, :tag_maps).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
-    @draft_articles = @user.articles.draft.order(created_at: :desc).limit(PER_PAGE)
+    @draft_articles = @user.articles.draft.order(updated_at: :desc).limit(PER_PAGE)
     @closed_articles = @user.articles.closed.order(updated_at: :desc).limit(PER_PAGE)
   end
 end

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -10,6 +10,6 @@ class MypageController < ApplicationController
     @user = User.with_attached_avatar.find(params[:id])
     @articles = @user.articles.published.includes(:keeps, :tags, :tag_maps).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     @draft_articles = @user.articles.draft.order(created_at: :desc).limit(PER_PAGE)
-    @closed_articles = @user.articles.closed.order(created_at: :desc).limit(PER_PAGE)
+    @closed_articles = @user.articles.closed.order(updated_at: :desc).limit(PER_PAGE)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,14 +1,4 @@
 module ApplicationHelper
-  def max_width
-    if controller_name == "articles" && action_name == "show"
-      "mw-md"
-    elsif devise_controller?
-      "mw-sm"
-    else
-      "mw-xl"
-    end
-  end
-
   def author?(article)
     article.user == current_user
   end

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,4 +1,4 @@
-<div class="article">
+<div class="article text-break">
   <div class="article-header">
     <%= image_tag user_icon(article.user, "list"), class:"user-icon" %>
     <%= link_to "@#{article.user.name}", mypage_path(article.user.id), class:"erb-link" %>

--- a/app/views/articles/closes/_closed_article.html.erb
+++ b/app/views/articles/closes/_closed_article.html.erb
@@ -1,4 +1,6 @@
-<div>
-  <h4><%= link_to "#{closed_article.title}", articles_close_path(closed_article), class:"erb-link" %></h4>
-  <hr>
+<div class="article">
+  <div class="update-time text-end">
+    <%= "#{update_data(closed_article)}に更新" %>
+  </div>
+  <h3><%= link_to "#{closed_article.title}", articles_close_path(closed_article), class:"erb-link" %></h3>
 </div>

--- a/app/views/articles/closes/index.html.erb
+++ b/app/views/articles/closes/index.html.erb
@@ -1,2 +1,3 @@
-<h1>非公開記事一覧</h1>
+<h1 class="text-center">非公開記事一覧</h1>
 <%= render partial: "closed_article", collection: @closed_articles %>
+<%= paginate @closed_articles%>

--- a/app/views/articles/closes/show.html.erb
+++ b/app/views/articles/closes/show.html.erb
@@ -1,4 +1,4 @@
-<div class="article-show mw-md mx-auto">
+<div class="article-show">
   <h1><%= @article.title %></h1>
   <p>
     <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>

--- a/app/views/articles/drafts/_draft_article.html.erb
+++ b/app/views/articles/drafts/_draft_article.html.erb
@@ -1,6 +1,6 @@
 <div class="article">
   <h3><%= link_to "#{draft_article.title}", articles_draft_path(draft_article), class:"erb-link" %></h3>
   <time datetime="<%= draft_article.created_at %>" class="text-muted">
-    <%= "#{time_ago_in_words(draft_article.created_at)}前に作成されました" %>
+    <%= "#{time_ago_in_words(draft_article.updated_at)}前" %>
   </time>
 </div>

--- a/app/views/articles/drafts/_draft_article.html.erb
+++ b/app/views/articles/drafts/_draft_article.html.erb
@@ -1,6 +1,6 @@
 <div class="article">
   <h3><%= link_to "#{draft_article.title}", articles_draft_path(draft_article), class:"erb-link" %></h3>
-  <time datetime="<%= draft_article.created_at %>">
-    <%= "#{time_ago_in_words(draft_article.created_at)}前" %>
+  <time datetime="<%= draft_article.created_at %>" class="text-muted">
+    <%= "#{time_ago_in_words(draft_article.created_at)}前に作成されました" %>
   </time>
 </div>

--- a/app/views/articles/drafts/_draft_article.html.erb
+++ b/app/views/articles/drafts/_draft_article.html.erb
@@ -1,4 +1,6 @@
-<div>
-  <h4><%= link_to "#{draft_article.title}", articles_draft_path(draft_article) %></h4>
-  <hr>
+<div class="article">
+  <h3><%= link_to "#{draft_article.title}", articles_draft_path(draft_article), class:"erb-link" %></h3>
+  <time datetime="<%= draft_article.created_at %>">
+    <%= "#{time_ago_in_words(draft_article.created_at)}前に作成" %>
+  </time>
 </div>

--- a/app/views/articles/drafts/_draft_article.html.erb
+++ b/app/views/articles/drafts/_draft_article.html.erb
@@ -1,6 +1,6 @@
 <div class="article">
   <h3><%= link_to "#{draft_article.title}", articles_draft_path(draft_article), class:"erb-link" %></h3>
   <time datetime="<%= draft_article.created_at %>">
-    <%= "#{time_ago_in_words(draft_article.created_at)}前に作成" %>
+    <%= "#{time_ago_in_words(draft_article.created_at)}前" %>
   </time>
 </div>

--- a/app/views/articles/drafts/index.html.erb
+++ b/app/views/articles/drafts/index.html.erb
@@ -1,2 +1,3 @@
-<h1>下書き記事一覧</h1>
+<h1 class="text-center">下書き記事一覧</h1>
 <%= render partial: "draft_article", collection: @draft_articles %>
+<%= paginate @draft_articles%>

--- a/app/views/articles/drafts/show.html.erb
+++ b/app/views/articles/drafts/show.html.erb
@@ -1,4 +1,4 @@
-<div class="article-show mw-md mx-auto">
+<div class="article-show">
   <h1><%= @article.title %></h1>
   <%= @article.content %>
   <div class="author d-flex justify-content-end">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,6 +1,6 @@
-<h3>検索結果</h3>
+<h3 class="text-center">検索結果</h3>
 <% if @search_articles.blank? %>
-  該当の記事が見つかりませんでした。
+  <p class="text-center mt-5">該当する記事が見つかりませんでした</p>
 <% else  %>
   <%= render @search_articles %>
 <% end %>

--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -1,3 +1,3 @@
-<h3><%= "タグ名「#{@tag.tag_name}」の投稿一覧" %></h3>
+<h3 class="text-center"><%= "タグ名「 #{@tag.tag_name} 」の投稿一覧" %></h3>
 <%= render @articles %>
 <%= paginate @articles %>

--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -1,3 +1,3 @@
-<h3 class="text-center"><%= "タグ名「 #{@tag.tag_name} 」の投稿一覧" %></h3>
+<h3 class="text-center"><%= "#{@tag.tag_name} を含む投稿一覧" %></h3>
 <%= render @articles %>
 <%= paginate @articles %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,4 +1,4 @@
-<div class="article-show">
+<div class="article-show text-break">
   <%= image_tag user_icon(@article.user, "list"), class:"user-icon" %>
   <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
   <%= "が#{update_data(@article)}に更新" %>
@@ -36,7 +36,7 @@
   <% end %>
 </div>
 
-<div class="user-profile">
+<div class="user-profile text-break">
   <%= image_tag user_icon(@article.user, "profile"), class:"user-icon" %>
   <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
   <p><%= simple_format(@article.user.profile)%></p>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('.title', resource: resource_name.to_s.humanize) %></h1>
+<h1 class="text-center"><%= t('.title', resource: resource_name.to_s.humanize) %></h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= bootstrap_devise_error_messages! %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('.sign_up') %></h1>
+<h1 class="text-center"><%= t('.sign_up') %></h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= bootstrap_devise_error_messages! %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('.sign_in') %></h1>
+<h1 class="text-center"><%= t('.sign_in') %></h1>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-group">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,6 +7,6 @@
 </div>
 
 
-<h3 class="text-center text-muted">最新の投稿</h3>
+<h3 class="text-center">最新の投稿</h3>
 <%= render @articles %>
 <%= paginate @articles %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,6 +7,6 @@
 </div>
 
 
-<h1 class="text-center text-muted">最新の投稿</h1>
+<h3 class="text-center text-muted">最新の投稿</h3>
 <%= render @articles %>
 <%= paginate @articles %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     </header>
     <main>
       <%= render "layouts/flash" %>
-      <div class="base-container <%= max_width %>">
+      <div class="base-container mw-md">
       <%= yield %>
     </main>
   </body>

--- a/app/views/mypage/index.html.erb
+++ b/app/views/mypage/index.html.erb
@@ -1,4 +1,4 @@
-<p>保存した記事一覧</p>
+<h3 class="text-center mb-4">保存した記事一覧</h3>
 
 <%= render @articles %>
 <%= paginate @articles %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -36,16 +36,12 @@
 
     <div class="tab-pane fade" id="draft" role="tabpanel" aria-labelledby="draft-tab">
       <%= render partial: "articles/drafts/draft_article", collection: @draft_articles %>
-      <div class="article-guide">
-        <%= link_to "下書き記事一覧へ", articles_drafts_path, class:"erb-link-btn btn btn-block main-btn" %>
-      </div>
+      <%= link_to "下書き記事一覧へ", articles_drafts_path, class:"erb-link-btn btn btn-block main-btn" %>
     </div>
 
     <div class="tab-pane fade" id="closed" role="tabpanel" aria-labelledby="closed-tab">
       <%= render partial: "articles/closes/closed_article", collection: @closed_articles %>
-      <div class="article-guide">
-        <%= link_to "非公開記事一覧へ", articles_closes_path, class:"erb-link-btn btn btn-block main-btn" %>
-      </div>
+      <%= link_to "非公開記事一覧へ", articles_closes_path, class:"erb-link-btn btn btn-block main-btn" %>
     </div>
   </div>
 <% else %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -12,24 +12,24 @@
     </div>
   </div>
 </div>
-<% if user_signed_in? && account_owner?(@user) %>
-  <%= link_to "プロフィール編集", profile_edit_path, class:"btn btn-block main-btn" %>
 
-  <ul class="text-center nav nav-tabs" id="myTab" role="tablist">
+<% if user_signed_in? && account_owner?(@user) %>
+  <%= link_to "プロフィール編集", profile_edit_path, class:"btn btn-block main-btn erb-link-btn mb-4" %>
+
+  <ul class="nav nav-pills" id="myTab" role="tablist">
     <li class="nav-item bg-light">
-      <a class="nav-link active link-text" id="published-tab" data-toggle="tab" href="#published" role="tab" aria-controls="published" aria-selected="true">公開記事</a>
+      <a class="nav-link active" id="published-tab" data-toggle="tab" href="#published" role="tab" aria-controls="published" aria-selected="true">公開記事</a>
     </li>
     <li class="nav-item bg-light">
-      <a class="nav-link link-text" id="draft-tab" data-toggle="tab" href="#draft" role="tab" aria-controls="draft" aria-selected="false">下書き</a>
+      <a class="nav-link" id="draft-tab" data-toggle="tab" href="#draft" role="tab" aria-controls="draft" aria-selected="false">下書き</a>
     </li>
     <li class="nav-item bg-light">
-      <a class="nav-link link-text" id="closed-tab" data-toggle="tab" href="#closed" role="tab" aria-controls="closed" aria-selected="false">非公開</a>
+      <a class="nav-link" id="closed-tab" data-toggle="tab" href="#closed" role="tab" aria-controls="closed" aria-selected="false">非公開</a>
     </li>
   </ul>
 
   <div class="tab-content" id="myTabContent">
     <div class="tab-pane fade show active" id="published" role="tabpanel" aria-labelledby="published-tab">
-      <div class="ml-1 mt-3 mb-2"></div>
       <%= render @articles %>
       <%= paginate @articles %>
     </div>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -36,12 +36,16 @@
 
     <div class="tab-pane fade" id="draft" role="tabpanel" aria-labelledby="draft-tab">
       <%= render partial: "articles/drafts/draft_article", collection: @draft_articles %>
-      <%= link_to "下書き記事一覧へ", articles_drafts_path %>
+      <div class="article-guide">
+        <%= link_to "下書き記事一覧へ", articles_drafts_path, class:"erb-link-btn btn btn-block main-btn" %>
+      </div>
     </div>
 
     <div class="tab-pane fade" id="closed" role="tabpanel" aria-labelledby="closed-tab">
       <%= render partial: "articles/closes/closed_article", collection: @closed_articles %>
-      <%= link_to "非公開記事一覧へ", articles_closes_path %>
+      <div class="article-guide">
+        <%= link_to "非公開記事一覧へ", articles_closes_path, class:"erb-link-btn btn btn-block main-btn" %>
+      </div>
     </div>
   </div>
 <% else %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -1,9 +1,17 @@
-
-<%= image_tag user_icon(@user, "mypage"), class:"user-icon" %>
-<p><%= "@#{@user.name}" %></p>
-<p><%= "投稿数#{@user.articles.published.count}" %></p>
-
-<%= simple_format(@user.profile) %>
+<div class="profile-contener text-break">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 col-lg-4 user-data">
+        <%= image_tag user_icon(@user, "mypage"), class:"user-icon mt-2" %>
+        <p><%= "@#{@user.name}" %></p>
+        <p><%= "投稿数#{@user.articles.published.count}" %></p>
+      </div>
+      <div class="col-12 col-lg-8 mt-4">
+        <%= simple_format(@user.profile) %>
+      </div>
+    </div>
+  </div>
+</div>
 <% if user_signed_in? && account_owner?(@user) %>
   <h3><%= link_to "プロフィール編集", profile_edit_path %></h3>
 

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -34,14 +34,12 @@
       <%= paginate @articles %>
     </div>
 
-    <div class="mb-5 tab-pane fade" id="draft" role="tabpanel" aria-labelledby="draft-tab">
-      <div class="ml-1 mt-5 mb-2"></div>
+    <div class="tab-pane fade" id="draft" role="tabpanel" aria-labelledby="draft-tab">
       <%= render partial: "articles/drafts/draft_article", collection: @draft_articles %>
       <%= link_to "下書き記事一覧へ", articles_drafts_path %>
     </div>
 
-    <div class="mb-5 tab-pane fade" id="closed" role="tabpanel" aria-labelledby="closed-tab">
-      <div class="ml-1 mt-5 mb-2"></div>
+    <div class="tab-pane fade" id="closed" role="tabpanel" aria-labelledby="closed-tab">
       <%= render partial: "articles/closes/closed_article", collection: @closed_articles %>
       <%= link_to "非公開記事一覧へ", articles_closes_path %>
     </div>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -49,7 +49,7 @@
     </div>
   </div>
 <% else %>
-  <h4>最近の投稿</h4>
+  <h4 class="text-center mt-4">最近の投稿</h4>
   <%= render @articles %>
   <%= paginate @articles %>
 <% end %>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -13,7 +13,7 @@
   </div>
 </div>
 <% if user_signed_in? && account_owner?(@user) %>
-  <h3><%= link_to "プロフィール編集", profile_edit_path %></h3>
+  <%= link_to "プロフィール編集", profile_edit_path, class:"btn btn-block main-btn" %>
 
   <ul class="text-center nav nav-tabs" id="myTab" role="tablist">
     <li class="nav-item bg-light">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,10 +2,10 @@
 ja:
   views:
     pagination:
-      first: "最初"
-      last: "最後"
-      previous: "前"
-      next: "次"
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>
       truncate: "..."
   enums:
     article:


### PR DESCRIPTION
close #120

## 実装内容
- マイページのデザインを変更内容は以下
  - プロフィール欄のデザインの
  - プロフィール編集ボタンの設置
  - タブのデザイン
  - ページネーションのデザイン
  - 全ページのタイトル文字を中央配置にし文字を`muted`に変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
