### PR TITLE
アイコン更新時に旧画像を削除

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -19,6 +19,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def update
+    current_user.update(configure_account_update_params)
+  end
+
   protected
 
     def configure_account_update_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   before_create :default_image
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :rememberable, :validatable
 
   has_one_attached :avatar
 


### PR DESCRIPTION
close #番126

## 実装内容
- アイコン更新時に旧画像がdb内に残ってしまっていたので更新時に削除するよう変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
