### PR TITLE
ユーザー情報変更時のバグの改修

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -160,8 +160,19 @@ body {
   color: #fff;
 }
 
-// フラッシュ
+.alert-danger {
+  background-color: $accent-color;
+  color: #fff;
+  .close {
+    color: #fff;
+    opacity: 1;
+    &:hover {
+      color: #fff;
+    }
+  }
+}
 
+// フラッシュ
 .alert-notice {
   background-color: $sub-color;
   color: #fff;

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,7 +11,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def profile_update
-    current_user.update(account_update_params)
+    current_user.update!(account_update_params)
     if current_user.save
       redirect_to mypage_path(current_user), notice: "プロフィールを更新しました"
     else

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,16 +11,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def profile_update
-    current_user.assign_attributes(account_update_params)
+    current_user.update(account_update_params)
     if current_user.save
       redirect_to mypage_path(current_user), notice: "プロフィールを更新しました"
     else
       render "profile_edit"
     end
-  end
-
-  def update
-    current_user.update(configure_account_update_params)
   end
 
   protected

--- a/app/views/devise/registrations/profile_edit.html.erb
+++ b/app/views/devise/registrations/profile_edit.html.erb
@@ -16,6 +16,6 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "更新", class: 'btn btn-block main-btn' %>
+    <%= f.submit "更新", class: 'btn btn-block main-btn erb-link-btn' %>
   </div>
 <% end %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -141,5 +141,5 @@ ja:
       not_found: は見つかりませんでした。
       not_locked: はロックされていません。
       not_saved:
-        one: エラーが発生したため %{resource} は保存されませんでした。
-        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+        one: エラーが発生したため %{resource} は保存されませんでした
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした"


### PR DESCRIPTION
close #130

## 実装内容
- アカウント編集で更新の時に出るエラーを改善
  - 以前定義した`registrations_controller`内の`update`を削除
- アカウント編集時の更新ボタンのhover時のデザインの修正漏れを改修
- 新規ユーザー登録の際のエラーボックスの色を変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
