### PR TITLE
Action Text内の画像へのバリテーションを実施

### DIFF
--- a/app/controllers/articles/closes_controller.rb
+++ b/app/controllers/articles/closes_controller.rb
@@ -11,7 +11,6 @@ class Articles::ClosesController < ApplicationController
 
   def destroy
     @article.destroy!
-    @article.images.purge
     redirect_to mypage_path(current_user)
   end
 

--- a/app/controllers/articles/drafts_controller.rb
+++ b/app/controllers/articles/drafts_controller.rb
@@ -11,7 +11,6 @@ class Articles::DraftsController < ApplicationController
 
   def destroy
     @article.destroy!
-    @article.images.purge
     redirect_to mypage_path(current_user)
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -21,7 +21,7 @@ class ArticlesController < ApplicationController
       @article.save_tag(@tag_list)
       choose_status
     else
-      flash.now[:alert] = "タイトルを記入してください"
+      flash.now[:alert] = "記事作成に失敗しました"
       render :new
     end
   end
@@ -46,14 +46,13 @@ class ArticlesController < ApplicationController
       @article.save_tag(tag_list)
       choose_status
     else
-      flash.now[:alert] = "タイトルを記入してください"
+      flash.now[:alert] = "記事作成に失敗しました"
       render :edit
     end
   end
 
   def destroy
     @article.destroy!
-    @article.images.purge
     redirect_to mypage_path(current_user)
   end
 
@@ -66,7 +65,7 @@ class ArticlesController < ApplicationController
   private
 
     def article_params
-      params.require(:article).permit(:title, :content, :images, :status)
+      params.require(:article).permit(:title, :content, :status)
     end
 
     def set_edit_article

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,7 +1,6 @@
 class ArticlesController < ApplicationController
-  before_action :correct_user, only: [:edit]
-  before_action :set_edit_article, only: %i[edit update destroy]
   before_action :authenticate_user!, only: %i[new create update destroy edit]
+  before_action :correct_user, only: %i[edit update destroy]
 
   def index
     @q = Article.published.ransack(params[:q])
@@ -66,10 +65,6 @@ class ArticlesController < ApplicationController
 
     def article_params
       params.require(:article).permit(:title, :content, :status)
-    end
-
-    def set_edit_article
-      @article = current_user.articles.find(params[:id])
     end
 
     def correct_user

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -7,9 +7,17 @@ class MypageController < ApplicationController
   end
 
   def show
+    check_blobs
     @user = User.with_attached_avatar.find(params[:id])
     @articles = @user.articles.published.includes(:keeps, :tags, :tag_maps).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     @draft_articles = @user.articles.draft.order(updated_at: :desc).limit(PER_PAGE)
     @closed_articles = @user.articles.closed.order(updated_at: :desc).limit(PER_PAGE)
   end
+
+  private
+
+    # 記事作成時にD&Dしたが使用せずにactive_storage_blobs内に浮遊しているデータの削除
+    def check_blobs
+      ActiveStorage::Blob.includes(:variant_records, :preview_image_attachment).unattached.each(&:purge) if ActiveStorage::Blob.unattached.any?
+    end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,10 +11,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def profile_update
-    current_user.update!(account_update_params)
+    current_user.update(account_update_params)
     if current_user.save
       redirect_to mypage_path(current_user), notice: "プロフィールを更新しました"
     else
+      flash.now[:alert] = "画像の保存に失敗しました。 5MB以下の画像ファイルのみ登録可能です"
       render "profile_edit"
     end
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ import * as ActiveStorage from "@rails/activestorage";
 import "channels";
 import "bootstrap/dist/js/bootstrap";
 import "@fortawesome/fontawesome-free/js/all";
+import "../trix-editor-overrides";
 
 Rails.start();
 Turbolinks.start();

--- a/app/javascript/trix-editor-overrides.js
+++ b/app/javascript/trix-editor-overrides.js
@@ -1,0 +1,19 @@
+window.addEventListener("trix-file-accept", function (event) {
+  const acceptedTypes = ["image/jpeg", "image/png", "image/jpg"];
+  if (!acceptedTypes.includes(event.file.type)) {
+    event.preventDefault();
+    alert("画像ファイル以外は投稿できません");
+  }
+  const maxFileSize = 1024 * 1024 * 5; // 5MB
+  if (event.file.size > maxFileSize) {
+    event.preventDefault();
+    alert("5MB以上の画像は投稿できません");
+  }
+
+  const maxFileCount = 9;
+  const fileCount = document.getElementsByTagName("figure").length;
+  if (fileCount > maxFileCount) {
+    event.preventDefault();
+    alert("1回の投稿では10枚が上限です");
+  }
+});

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -21,7 +21,6 @@ class Article < ApplicationRecord
   has_many :tags, through: :tag_maps
 
   has_rich_text :content
-  has_many_attached :images
 
   def liked_by?(user)
     likes.any? {|like| like.user_id == user.id }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,8 @@ class User < ApplicationRecord
   end
 
   def avatar_check
+    return unless avatar.attached?
+
     if !avatar.content_type.in?(%('image/jpeg image/png image/jpg'))
       errors.add(:avatar, "はjpeg, png, jpgが保存可能です")
     elsif avatar.attachment.byte_size >= 5.megabytes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,8 @@ class User < ApplicationRecord
   validates :profile, length: { maximum: 200 }
   validates :email, { uniqueness: { case_sensitive: false } }
 
+  validate :avatar_check
+
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64
@@ -33,6 +35,14 @@ class User < ApplicationRecord
     unless self.avatar.attached?
       self.avatar.attach(io: File.open(Rails.root.join("app", "assets", "images", "event_default.png")), filename: "event_default.png",
                          content_type: "image/png")
+    end
+  end
+
+  def avatar_check
+    if !avatar.content_type.in?(%('image/jpeg image/png image/jpg'))
+      errors.add(:avatar, "はjpeg, png, jpgが保存可能です")
+    elsif avatar.attachment.byte_size >= 5.megabytes
+      errors.add(:avatar, "には最大5MBまでの画像が登録できます")
     end
   end
 end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,5 +1,7 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
-  <%= image_tag blob.variant(resize: "500x500").processed if blob.representable?%>
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
 
   <figcaption class="attachment__caption">
     <% if caption = blob.try(:caption) %>

--- a/config/rubocop/rails.yml
+++ b/config/rubocop/rails.yml
@@ -55,3 +55,8 @@ Rails/UnknownEnv:
 # seedに"put"でメッセージを表示したい
 Rails/Output:
   Enabled: false
+
+
+# save・update時に条件分岐を使用したい
+Rails/SaveBang:
+  Enabled: false


### PR DESCRIPTION
close #135

## 実装内容
- `Action Text`使用時の画像のバリテーションの実施( jsにて実装 )
  - `app/javascript/trix-editor-overrides.js `を作成
  - 添付ファイルは` jpeg, png, jpg` のみ許可
  - 5MB / 枚を容量の上限に設定
  - 1回の投稿で10枚まで画像添付許可
  - 上記に反した場合は`alert`で告知されるように実装
  - 画像の追加・変更時に不具合が起きたが、以前`_blob.html.erb`を触った事が原因だったので該当箇所を修正し解決
- 画像添付時に未使用でもDB(`active_storage_blobs_table`)に保存されるデータを削除するように実装
- 実装時に不要になった記述など一部修正

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
