### PR TITLE
Article モデルのバリテーションを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -145,6 +145,9 @@ body {
   font-weight: bold;
   letter-spacing: 0.5em;
 }
+.label_color {
+  color: #6c757d;
+}
 
 /* ボタン */
 .main-btn {

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -20,7 +20,7 @@ class ArticlesController < ApplicationController
       @article.save_tag(@tag_list)
       choose_status
     else
-      flash.now[:alert] = "記事作成に失敗しました"
+      flash.now[:alert] = "記事の作成に失敗しました"
       render :new
     end
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,7 +15,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if current_user.save
       redirect_to mypage_path(current_user), notice: "プロフィールを更新しました"
     else
-      flash.now[:alert] = "画像の保存に失敗しました。 5MB以下の画像ファイルのみ登録可能です"
+      flash.now[:alert] = "更新に失敗しました"
       render "profile_edit"
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,6 +2,7 @@ class Article < ApplicationRecord
   with_options presence: true do
     validates :title
     validates :status
+    validates :content, presence: true, if: -> { status == "published" }
   end
 
   enum status: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
     if !avatar.content_type.in?(%('image/jpeg image/png image/jpg'))
       errors.add(:avatar, "はjpeg, png, jpgが保存可能です")
     elsif avatar.attachment.byte_size >= 5.megabytes
-      errors.add(:avatar, "には最大5MBまでの画像が登録できます")
+      errors.add(:avatar, "は最大5MBまでの画像が登録できます")
     end
   end
 end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,15 +1,16 @@
 <div class="form-group">
   <%= form_with model: @article, local: true do |f| %>
+    <%= render "layouts/error_messages", model: @article %>
     <p>
-      <%= f.label :title, class:"form-label"  %>
-      <%= f.text_field :title, placeholder: "タイトル", required: true, class:"form-control form" %>
+      <%= f.label :title, class:"label_color"  %>
+      <%= f.text_field :title, required: true, placeholder: "タイトル", class:"form-control form" %>
     </p>
     <p>
-      <%= f.label :tag_name, class:"form-label" %>
+      <%= f.label :tag_name, class:"label_color" %>
       <%= f.text_field :tag_name, value: @tag_list, placeholder: "スペース区切りで入力 (例: 外科 手術)", class:"form-control form" %>
     </p>
     <p>
-      <%= f.label :content %>
+      <%= f.label :content, class:"label_color" %>
       <%= f.rich_text_area :content, placeholder: "あなたの学びを共有しよう" %>
     </p>
     <%= f.select :status, Article.statuses_i18n.invert, {}, class: 'form-control form' %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,24 +4,24 @@
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group">
-    <%= f.label :email %>
+    <%= f.label :email, class:"label_color" %>
     <%= f.email_field :email, autocomplete: 'email', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :password %>
+    <%= f.label :password, class:"label_color" %>
     <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control form' %>
 
     <small class="form-text text-muted"><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></small>
   </div>
 
   <div class="form-group">
-    <%= f.label :password_confirmation %>
+    <%= f.label :password_confirmation, class:"label_color" %>
     <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control form'  %>
   </div>
 
   <div class="form-group">
-    <%= f.label :current_password %>
+    <%= f.label :current_password, class:"label_color" %>
     <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control form' %>
 
     <small class="form-text text-muted"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></small>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,17 +4,17 @@
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group">
-    <%= f.label :name %>
+    <%= f.label :name, class:"label_color" %>
     <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :email %>
+    <%= f.label :email, class:"label_color" %>
     <%= f.email_field :email, autocomplete: 'email', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :password %>
+    <%= f.label :password, class:"label_color" %>
     <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control form' %>
     <% if @minimum_password_length %>
       <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
@@ -22,7 +22,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :password_confirmation %>
+    <%= f.label :password_confirmation, class:"label_color" %>
     <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control form' %>
   </div>
 

--- a/app/views/devise/registrations/profile_edit.html.erb
+++ b/app/views/devise/registrations/profile_edit.html.erb
@@ -1,17 +1,19 @@
-<%= form_for current_user, url: profile_update_path do |f| %>
+<h1 class="text-center">プロフィール編集</h1>
 
+<%= form_for current_user, url: profile_update_path do |f| %>
+  <%= render "layouts/error_messages", model: current_user %>
   <div class="form-group">
-    <%= f.label :name %>
+    <%= f.label :name, class:"label_color" %>
     <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :profile %>
+    <%= f.label :profile, class:"label_color" %>
     <%= f.text_area :profile, class: 'form-control form', style:"height:200px"%>
   </div>
 
   <div class="form-group">
-    <%= f.label :avatar, "ユーザーアイコン" %>
+    <%= f.label :avatar, "ユーザーアイコン", class:"label_color" %>
     <%= f.file_field :avatar, accept: "image/jpeg,image/png,image/jpg", class: 'form-control form' %>
   </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,12 +2,12 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-group">
-    <%= f.label :email %>
+    <%= f.label :email, class:"label_color" %>
     <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control form' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :password %>
+    <%= f.label :password, class:"label_color" %>
     <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control form' %>
   </div>
 

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div class="alert-alert my-4 p-4">
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -27,6 +27,7 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
+        avatar: ユーザーアイコン
     models:
       user: ユーザー
   devise:

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Article, type: :model do
       end
     end
 
-    context "statusがdraftのとき" do
+    context "statusがdraft" do
       context "contentがnilでも" do
         let(:article) { build(:article, :draft, content: nil) }
         it "下書き記事を作成できる" do
@@ -45,7 +45,7 @@ RSpec.describe Article, type: :model do
       end
     end
 
-    context "statusがclosedのとき" do
+    context "statusがclosed" do
       context "contentがnilでも" do
         let(:article) { build(:article, :closed, content: nil) }
         it "非公開記事を作成できる" do
@@ -54,7 +54,6 @@ RSpec.describe Article, type: :model do
         end
       end
     end
-
   end
 
   describe "異常系" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2,15 +2,16 @@ require "rails_helper"
 
 RSpec.describe Article, type: :model do
   describe "正常系" do
-    context "タイトルと本文と公開レベルが指定されているとき" do
+    context "タイトルと本文が存在するとき" do
       let(:article) { build(:article) }
       it "公開状態で記事が作成される" do
-        expect(article).to be_valid
+        expect(article.content.body.present?).to eq true
         expect(article.status).to eq "published"
+        expect(article).to be_valid
       end
     end
 
-    context "statusがpublishedのとき" do
+    context "必要情報が記載されstatusがpublishedのとき" do
       let(:article) { build(:article, :published) }
       it "公開状態で記事を作成できる" do
         expect(article).to be_valid
@@ -33,6 +34,27 @@ RSpec.describe Article, type: :model do
         expect(article.status).to eq "closed"
       end
     end
+
+    context "statusがdraftのとき" do
+      context "contentがnilでも" do
+        let(:article) { build(:article, :draft, content: nil) }
+        it "下書き記事を作成できる" do
+          expect(article).to be_valid
+          expect(article.status).to eq "draft"
+        end
+      end
+    end
+
+    context "statusがclosedのとき" do
+      context "contentがnilでも" do
+        let(:article) { build(:article, :closed, content: nil) }
+        it "非公開記事を作成できる" do
+          expect(article).to be_valid
+          expect(article.status).to eq "closed"
+        end
+      end
+    end
+
   end
 
   describe "異常系" do
@@ -44,11 +66,20 @@ RSpec.describe Article, type: :model do
       end
     end
 
-    context "contentが無いとき" do
-      let(:article) { build(:article, content: nil) }
-      it "記事の作成に失敗する" do
+    context "公開記事のcontentが無いとき" do
+      let(:article) { build(:article, :published, content: nil) }
+      it "公開記事の作成に失敗する" do
+        expect(article.content.body.blank?).to eq true
         expect(article).to be_invalid
         expect(article.errors.details[:content][0][:error]).to eq :blank
+      end
+    end
+
+    context "statusがないとき" do
+      let(:article) { build(:article, status: nil) }
+      it "記事の作成に失敗する" do
+        expect(article).to be_invalid
+        expect(article.errors.details[:status][0][:error]).to eq :blank
       end
     end
   end


### PR DESCRIPTION
close #136

## 実装内容
- `Article model  content`にバリテーションを追加
  - `status: "published"`の時だけ`presence: true`を実行
  - 「下書き・非公開」時は空欄でも投稿可能に設定
  - 設定変更に伴い`RSpecのModelテスト`を一部変更
- バリテーション失敗時の内容を表示するように変更
  - flashの内容を変更し具体的なエラーは下記のファイルで表示
  - `layouts/_error_messages.html.erb`を作成
  - 記事投稿画面・プロフィール編集画面でエラー内容を表示するように実装
- 各フォームを表示するページの`label`にクラスを付与し黒文字を灰色に変更し全体と統一

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
