### PR TITLE
保存一覧の表示内容を変更

### DIFF
--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -2,8 +2,8 @@ class MypageController < ApplicationController
   before_action :authenticate_user!, only: %i[index]
   # 保存した記事一覧のページ
   def index
-    @articles = current_user.kept_articles.includes(:tag_maps, :tags, :keeps,
-                                                    user: { avatar_attachment: :blob }).order("keeps.created_at desc").page(params[:page]).per(PER_PAGE)
+    @articles = current_user.kept_articles.published.includes(:tag_maps, :tags, :keeps,
+                                                              user: { avatar_attachment: :blob }).order("keeps.created_at desc").page(params[:page]).per(PER_PAGE)
   end
 
   def show

--- a/config/rubocop/rubocop.yml
+++ b/config/rubocop/rubocop.yml
@@ -134,7 +134,7 @@ Metrics/CyclomaticComplexity:
 # * 禁止 160文字
 # のイメージ
 Metrics/LineLength:
-  Max: 160
+  Max: 165
   Exclude:
     - "db/migrate/*.rb"
 


### PR DESCRIPTION
close #149

## 実装内容
- 保存記事一覧の表示内容の変更
  - `status`を公開から非公開に変更後も他のユーザーの一覧に表示されていた
  - 表示から詳細に移動するとエラーが発生していた
  - なので一覧に表示されるのは`status`が公開の物のみに変更しエラーを回避
- Rubocopの文字数字制限に引っかかったので上限を`160→165`に変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
