### PR TITLE
検索結果に重複除外処理を実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,8 +4,8 @@ class ArticlesController < ApplicationController
 
   def index
     @q = Article.published.ransack(params[:q])
-    @search_articles = @q.result.order(created_at: :desc).includes(:keeps, :tags, :tag_maps,
-                                                                   user: { avatar_attachment: :blob }).page(params[:page]).per(PER_PAGE)
+    @search_articles = @q.result(distinct: true).order(created_at: :desc).includes(:keeps, :tags, :tag_maps,
+                                                                                   user: { avatar_attachment: :blob }).page(params[:page]).per(PER_PAGE)
   end
 
   def new
@@ -57,8 +57,8 @@ class ArticlesController < ApplicationController
 
   def search
     @tag = Tag.find(params[:tag_id])
-    @articles = @tag.articles.published.includes(:keeps, :tags, :tag_maps,
-                                                 user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    @articles = @tag.articles.published.distinct.includes(:keeps, :tags, :tag_maps,
+                                                          user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
   private


### PR DESCRIPTION
close #152

## 実装内容
- 検索結果ページに重複記事が表示されるのを修正
- 同一タグが２個ある時も重複表示されるのでこちらも修正

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
