### PR TITLE
rakeタスクの作成

### DIFF
--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -7,17 +7,9 @@ class MypageController < ApplicationController
   end
 
   def show
-    check_blobs
     @user = User.with_attached_avatar.find(params[:id])
     @articles = @user.articles.published.includes(:keeps, :tags, :tag_maps).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     @draft_articles = @user.articles.draft.order(updated_at: :desc).limit(PER_PAGE)
     @closed_articles = @user.articles.closed.order(updated_at: :desc).limit(PER_PAGE)
   end
-
-  private
-
-    # 記事作成時にD&Dしたが使用せずにactive_storage_blobs内に浮遊しているデータの削除
-    def check_blobs
-      ActiveStorage::Blob.includes(:variant_records, :preview_image_attachment).unattached.each(&:purge) if ActiveStorage::Blob.unattached.any?
-    end
 end

--- a/lib/tasks/clean_active_storage_blobs.rake
+++ b/lib/tasks/clean_active_storage_blobs.rake
@@ -1,5 +1,5 @@
 namespace :clean_active_storage_blobs do
-  desc "ActionTextに添付したが使用しなかった画像データを削除するタスク"
+  desc "ActionTextに添付したが使用しなかった画像データを削除"
   task metadata: :environment do
     ActiveStorage::Blob.includes(:variant_records, :preview_image_attachment).unattached.each(&:purge) if ActiveStorage::Blob.unattached.any?
   end

--- a/lib/tasks/clean_active_storage_blobs.rake
+++ b/lib/tasks/clean_active_storage_blobs.rake
@@ -1,0 +1,6 @@
+namespace :clean_active_storage_blobs do
+  desc "ActionTextに添付したが使用しなかった画像データを削除するタスク"
+  task metadata: :environment do
+    ActiveStorage::Blob.includes(:variant_records, :preview_image_attachment).unattached.each(&:purge) if ActiveStorage::Blob.unattached.any?
+  end
+end

--- a/lib/tasks/clean_tags.rake
+++ b/lib/tasks/clean_tags.rake
@@ -1,0 +1,9 @@
+namespace :clean_tags do
+  desc "参照されていないタグデータの削除を行う"
+  task tag_name: :environment do
+    use_tags = TagMap.pluck(:tag_id)
+    unuse_tags = Tag.pluck(:id)
+    clean_tags = unuse_tags - use_tags
+    Tag.delete(clean_tags)
+  end
+end


### PR DESCRIPTION
close #154

## 実装内容
- `Heroku Scheduler`を本番環境に導入
  - `rake` タスクを作成
  - 不要な`Active_storage_blobs`のデータを削除するタスク
  - 記事の編集や削除により参照されていないタグデータの削除を行うタスク
- `heroku`上で毎週火曜午前4時に稼働するように設定

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
