### PR TITLE
ActiveStorageのvariant使用によるN+1問題の対策

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -6,3 +6,9 @@ $other-color: #847f7d;
 $main-background-color: #fff4e1;
 $article-list-color: #f8f8f8;
 $article-list-border-color: #cac8c8;
+
+@mixin icon_size($size: 25px) {
+  border-radius: 50%;
+  width: $size;
+  height: $size;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -129,8 +129,16 @@ body {
 .fa-tags {
   color: $accent-color;
 }
-.user-icon {
-  border-radius: 50%;
+
+/* アイコンサイズ */
+.list-user-icon {
+  @include icon_size;
+}
+.profile-user-icon {
+  @include icon_size(64px);
+}
+.mypage-user-icon {
+  @include icon_size(72px);
 }
 
 /* _form */

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,13 +18,11 @@ module ApplicationHelper
   def user_icon(user, size)
     case size
     when "mypage"
-      user.avatar.variant(resize: "72x72").processed
+      user.avatar
     when "profile"
-      user.avatar.variant(resize: "64x64").processed
-    when "header"
-      user.avatar.variant(resize: "32x32").processed
+      user.avatar
     when "list"
-      user.avatar.variant(resize: "25x25").processed
+      user.avatar
     end
   end
 end

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,6 +1,6 @@
 <div class="article text-break">
   <div class="article-header">
-    <%= image_tag user_icon(article.user, "list"), class:"user-icon" %>
+    <%= image_tag user_icon(article.user, "list"), class:"list-user-icon" %>
     <%= link_to "@#{article.user.name}", mypage_path(article.user.id), class:"erb-link" %>
     <%= "が#{creation_date(article)}に投稿" %>
   </div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,5 +1,5 @@
 <div class="article-show text-break">
-  <%= image_tag user_icon(@article.user, "list"), class:"user-icon" %>
+  <%= image_tag user_icon(@article.user, "list"), class:"list-user-icon" %>
   <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
   <%= "が#{update_data(@article)}に更新" %>
 
@@ -37,7 +37,7 @@
 </div>
 
 <div class="user-profile text-break">
-  <%= image_tag user_icon(@article.user, "profile"), class:"user-icon" %>
+  <%= image_tag user_icon(@article.user, "profile"), class:"profile-user-icon" %>
   <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
   <p><%= simple_format(@article.user.profile)%></p>
 </div>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col-12 col-lg-4 user-data">
-        <%= image_tag user_icon(@user, "mypage"), class:"user-icon mt-3" %>
+        <%= image_tag user_icon(@user, "mypage"), class:"mypage-user-icon mt-3" %>
         <p><%= "@#{@user.name}" %></p>
         <p><%= "投稿数#{@user.articles.published.count}" %></p>
       </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true # raise an error if n+1 query occurs
+  end
+
   # config.after_initialize do
   #   Bullet.enable        = true
   #   Bullet.bullet_logger = true


### PR DESCRIPTION
close #156

## 実装内容
- `application_helper.rb`にある`user.avatar.variant(resize: "72x72").processed`の`variant`以降の記述を削除
- サイズの調整はcssで行うように実装
  - アイコンサイズの指定処理を`mixin`を使用し実装
  - 使用するサイズに合わせクラス名を変更

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
