### PR TITLE
戻るボタンの実装

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -17,3 +17,15 @@ $article-list-border-color: #cac8c8;
   background-color: $color;
   color: #fff;
 }
+
+@mixin article_btn($color: $main-color) {
+  margin-top: 10px;
+  width: 100%;
+  height: 50px;
+  color: #fff;
+  background-color: $color;
+  border: 1px solid $color;
+  border-radius: 10px;
+  font-weight: bold;
+  letter-spacing: 0.5em;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -146,17 +146,13 @@ body {
   border: 1px solid $main-color;
   height: 50px;
 }
-.post-button {
-  margin-top: 10px;
-  width: 100%;
-  height: 50px;
-  color: #fff;
-  background-color: $main-color;
-  border: 1px solid $main-color;
-  border-radius: 10px;
-  font-weight: bold;
-  letter-spacing: 0.5em;
+.post-btn {
+  @include article_btn;
 }
+.cancel-btn {
+  @include article_btn($other-color);
+}
+
 .label_color {
   color: #6c757d;
 }

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -14,6 +14,7 @@
       <%= f.rich_text_area :content, placeholder: "あなたの学びを共有しよう" %>
     </p>
     <%= f.select :status, Article.statuses_i18n.invert, {}, class: 'form-control form' %>
-    <%= f.submit "投稿", class:"post-button" %>
+    <%= f.submit "投稿", class:"post-btn" %>
   <% end %>
+  <%= link_to "取り消し",:back, class: "btn btn-block cancel-btn mt-5", data: { confirm: "作成データを破棄しますか？" } %>
 </div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -41,6 +41,7 @@
   <%= link_to "@#{@article.user.name}", mypage_path(@article.user.id), class:"erb-link" %>
   <p><%= simple_format(@article.user.profile)%></p>
 </div>
+<%= link_to "戻る",:back, class: "btn other-btn btn-block"  %>
 
 <div class="author float-right">
   <% if author?(@article) %>


### PR DESCRIPTION
close #162

## 実装内容
- 記事詳細ページに「戻る」ボタンを配置
- 記事作成ページに「取り消し」ボタンを配置
  - 誤操作予防で削除確認を入れた
- ボタンデザインが重複した部分は`mixin`で共通化

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
