### PR TITLE
リンクタグのデザイン修正

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -29,3 +29,9 @@ $article-list-border-color: #cac8c8;
   font-weight: bold;
   letter-spacing: 0.5em;
 }
+
+@mixin alert_color($color: $sub-color) {
+  background-color: $color;
+  color: #fff;
+  margin-top: -5px;
+} ;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,14 +34,13 @@ a {
   color: $main-color;
   &:hover {
     color: $main-color;
-    text-decoration: none;
   }
 }
 
 .erb-link {
   color: black;
   &:hover {
-    color: black;
+    color: #6c757d;
   }
 }
 .erb-link-btn {
@@ -182,15 +181,11 @@ body {
 
 // フラッシュ
 .alert-notice {
-  background-color: $sub-color;
-  color: #fff;
-  margin-top: -5px;
+  @include alert_color;
 }
 
 .alert-alert {
-  background-color: $accent-color;
-  color: #fff;
-  margin-top: -5px;
+  @include alert_color($accent-color);
 }
 
 /* ページネーション */

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -16,11 +16,8 @@
   justify-content: space-between;
 
   .like-icon {
-    color: $accent-color;
     margin: 0 0.5rem;
-    &:hover {
-      text-decoration-color: $article-list-color;
-    }
+    color: $accent-color;
   }
   .like-count {
     font-size: 1.5rem;

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -12,7 +12,7 @@
     </p>
   </div>
   <div class="article-content">
-    <h4><%= link_to "#{article.title}", article_path(article), class:"erb-link" %></h4>
+    <h4><%= link_to "#{article.title}", article_path(article), class:"btn-block erb-link" %></h4>
   </div>
 
   <div class="reaction">

--- a/app/views/articles/closes/_closed_article.html.erb
+++ b/app/views/articles/closes/_closed_article.html.erb
@@ -2,5 +2,5 @@
   <div class="update-time text-end">
     <%= "#{update_data(closed_article)}に更新" %>
   </div>
-  <h3><%= link_to "#{closed_article.title}", articles_close_path(closed_article), class:"erb-link" %></h3>
+  <h3><%= link_to "#{closed_article.title}", articles_close_path(closed_article), class:"btn-block erb-link" %></h3>
 </div>

--- a/app/views/articles/drafts/_draft_article.html.erb
+++ b/app/views/articles/drafts/_draft_article.html.erb
@@ -1,5 +1,5 @@
 <div class="article">
-  <h3><%= link_to "#{draft_article.title}", articles_draft_path(draft_article), class:"erb-link" %></h3>
+  <h3><%= link_to "#{draft_article.title}", articles_draft_path(draft_article), class:"btn-block erb-link" %></h3>
   <time datetime="<%= draft_article.created_at %>" class="text-muted">
     <%= "#{time_ago_in_words(draft_article.updated_at)}前" %>
   </time>


### PR DESCRIPTION
close #164

## 実装内容
- リンクタグのホバー時の演出を再度使用
- 記事一覧部でタイトル周辺もクリック範囲に変更
- `scss`内の重複コードの`mixin`を使用し共通化

## 参考資料（必要であれば）

## チェックリスト

【注意】プルリクを出した後，クリックしてチェックを入れる

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## スクリーンショット（必要であれば）

## 備考（必要であれば）
